### PR TITLE
[DPE-5259] Release service account on relation-broken instead of relation-departed

### DIFF
--- a/src/relations/spark_sa.py
+++ b/src/relations/spark_sa.py
@@ -25,7 +25,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     RequirerData,
     RequirerEventHandlers,
 )
-from ops import Model, RelationCreatedEvent, RelationDepartedEvent, SecretChangedEvent
+from ops import Model, RelationCreatedEvent, SecretChangedEvent
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -183,8 +183,8 @@ class IntegrationHubProviderEventHandlers(EventHandlers):
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
         self.framework.observe(
-            charm.on[self.relation_data.relation_name].relation_departed,
-            self._on_relation_departed,
+            charm.on[self.relation_data.relation_name].relation_broken,
+            self._on_relation_broken,
         )
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
@@ -200,8 +200,8 @@ class IntegrationHubProviderEventHandlers(EventHandlers):
                 event.relation, app=event.app, unit=event.unit
             )
 
-    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
-        """React to the relation changed event by consuming data."""
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """React to the relation broken event by releasing the service account."""
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return


### PR DESCRIPTION
Currently, Spark Integration Hub tears down the service account when receiving the relation-departed event. So far, it worked because we were only working with 1 unit of Kyuubi with no HA supported.

Now that we are working on HA feature in Kyuubi; while testing scale-down on Kyuubi, it was discovered that Spark Integration Hub tries to tear down the service account multiple times and thus fails. It is because Spark Integration Hub currently tears down service account on receiving relation-departed event, but this event is triggered once every kyuubi unit is removed, even if the relation still exists. The teardown should happen instead on relation-broken and only in leader unit so that it gets triggered only when relation is broken or the application is removed.