### PR TITLE
Fix minio setup script to use secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v13.1.2
     with:
       path-to-charm-directory: ${{ matrix.path }}
-      cache: true
+      cache: false
 
   integration-test:
     strategy:
@@ -85,7 +85,7 @@ jobs:
       - name: Download packed charm(s)
         uses: actions/download-artifact@v4
         with:
-          pattern: packed-charm-cache-true-*
+          pattern: packed-charm-cache-*
           merge-multiple: true
       - name: Select tests
         id: select-tests

--- a/tests/integration/setup/setup_minio.sh
+++ b/tests/integration/setup/setup_minio.sh
@@ -4,26 +4,23 @@ attempt=1
 while [ $attempt -le 10 ]
 do
   echo "s3 params setup attempt=$attempt"
+  access_key=$(kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d)
   if [ -z "$access_key" ]; then
-    sudo microk8s.kubectl get secret -n minio-operator microk8s-user-1
-    if [ $? -eq 0 ]; then
-      echo "Use access-key from secret"
-    else
-      echo "use default access-key"
-      access_key="minio"
-    fi
+    echo "Use default access-key"
+    access_key="minio"
+  else
+    echo "Use access-key from secret"
   fi
+  secret_key=$(kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d)
   if [ -z "$secret_key" ]; then
-    sudo microk8s.kubectl get secret -n minio-operator microk8s-user-1
-    if [ $? -eq 0 ]; then
-      echo "secret_key=$secret_key"
-    else
-      echo "Use default secret-key"
-      secret_key="minio123"
-    fi
+    echo "Use default secret-key"
+    secret_key="minio123"
+  else
+    echo "Use secret-key from secret"
   fi
+
   if [ -z "$endpoint_ip" ]; then
-    endpoint_ip=$(sudo microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }')
+    endpoint_ip=$(kubectl get services -n minio-operator | grep minio | awk '{ print $3 }')
     endpoint="http://$endpoint_ip:80"
     echo "endpoint=$endpoint"
   fi


### PR DESCRIPTION
Fix usage of secrets in script, so access and secret key can be obtained from secret.

I also remove usage of `sudo microk8s`, since locally it does not make sense and in CI it's also ok, since kubectl is configured.

How I tested it:
```bash
$ sudo snap install microk8s --channel=1.28-strict
$ sudo usermod -a -G microk8s $USER
$ mkdir -p ~/.kube
$ chmod 0700 ~/.kube
$ su - $USER
$ microk8s status --wait-ready
$ ./tests/integration/setup/setup_minio.sh
...
```

fixes: #26