### PR TITLE
[DPE-6427] Fix list-config action output with capitalized props

### DIFF
--- a/src/events/configuration_actions.py
+++ b/src/events/configuration_actions.py
@@ -3,9 +3,11 @@
 # See LICENSE file for licensing details.
 
 """Event handlers for configuration-related Juju Actions."""
+
+import json
 import logging
 import re
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from ops.charm import ActionEvent
 from ops.framework import Object
@@ -131,10 +133,10 @@ class ConfigurationActionEvents(Object):
 
         configuration = self.context.hub_configurations.spark_configurations
         logger.info(f"Get configuration: {configuration}")
-        event.set_results(configuration)
+        event.set_results({"properties": json.dumps(configuration)})
         return
 
-    def _parse_property_line(self, line: str) -> Tuple[str, str]:  # type: ignore
+    def _parse_property_line(self, line: str) -> tuple[str, str]:
         prop_assignment = list(filter(None, re.split("=| ", line.strip())))
         prop_key = prop_assignment[0].strip()
         option_assignment = line.split("=", 1)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -377,7 +377,7 @@ async def test_actions(ops_test: OpsTest, namespace, service_account, conf_key, 
     )
     logger.info(f"namespace: {namespace} -> secret_data: {secret_data}")
     assert len(secret_data) > 0
-    assert conf_key in flatten(res)
+    assert conf_key in flatten(json.loads(res.get("properties", {})))
 
     # Remove inserted config
     res = await run_action(ops_test, "remove-config", {"key": conf_key})
@@ -469,7 +469,6 @@ async def test_add_new_service_account_with_config_value_containing_equals_sign(
 
 @pytest.mark.abort_on_fail
 async def test_relation_to_s3(ops_test: OpsTest, charm_versions, namespace, service_account):
-
     logger.info("Relating spark integration hub charm with s3-integrator charm")
     service_account_name = service_account[0]
     secret_data = get_secret_data(
@@ -523,7 +522,6 @@ async def test_add_new_service_account_with_s3(ops_test: OpsTest, namespace, ser
 async def test_add_removal_s3_relation(
     ops_test: OpsTest, namespace, service_account, charm_versions
 ):
-
     service_account_name = service_account[0]
 
     # wait for the update of secrets
@@ -582,7 +580,6 @@ async def test_add_removal_s3_relation(
 async def test_relation_to_both_s3_and_azure_storage_at_same_time(
     ops_test: OpsTest, charm_versions
 ):
-
     logger.info(
         "Relating spark integration hub charm with azure-storage-integrator along with existing relation with s3-integrator charm"
     )
@@ -625,7 +622,6 @@ async def test_relation_to_both_s3_and_azure_storage_at_same_time(
 async def test_relation_to_azure_storage(
     ops_test: OpsTest, charm_versions, namespace, service_account, azure_credentials
 ):
-
     logger.info("Relating spark integration hub charm with azure-storage-integrator charm")
     service_account_name = service_account[0]
     secret_data = get_secret_data(
@@ -746,7 +742,6 @@ async def test_add_removal_azure_storage_relation(
 async def test_relation_to_pushgateway(
     ops_test: OpsTest, charm_versions, namespace, service_account
 ):
-
     logger.info("Relating spark integration hub charm with s3-integrator charm")
     service_account_name = service_account[0]
     # namespace= ops_test.model_name

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,6 @@ from constants import CONTAINER, PEER
 
 
 def parse_spark_properties(out: State, tmp_path: Path) -> dict[str, str]:
-
     spark_properties_path = (
         out.get_container(CONTAINER)
         .layers["base"]
@@ -31,7 +30,7 @@ def parse_spark_properties(out: State, tmp_path: Path) -> dict[str, str]:
         )
 
 
-def test_start_integration_hub(integration_hub_ctx):
+def test_start_integration_hub(integration_hub_ctx: Context) -> None:
     state = State(
         config={},
         containers=[Container(name=CONTAINER, can_connect=False)],
@@ -41,7 +40,9 @@ def test_start_integration_hub(integration_hub_ctx):
 
 
 @patch("workload.IntegrationHub.exec")
-def test_pebble_ready(exec_calls, integration_hub_ctx, integration_hub_container):
+def test_pebble_ready(
+    exec_calls, integration_hub_ctx: Context, integration_hub_container: Container
+) -> None:
     state = State(
         containers=[integration_hub_container],
     )
@@ -60,11 +61,11 @@ def test_pebble_ready(exec_calls, integration_hub_ctx, integration_hub_container
 def test_s3_relation_connection_ok(
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    s3_relation,
-):
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    s3_relation: Relation,
+) -> None:
     state = State(
         relations=[s3_relation],
         containers=[integration_hub_container],
@@ -103,12 +104,12 @@ def test_s3_relation_connection_ok(
 def test_s3_relation_connection_ok_tls(
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    s3_relation_tls,
-    s3_relation,
-):
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    s3_relation_tls: Relation,
+    s3_relation: Relation,
+) -> None:
     state = State(
         relations=[s3_relation_tls],
         containers=[integration_hub_container],
@@ -118,7 +119,6 @@ def test_s3_relation_connection_ok_tls(
         patch("managers.k8s.KubernetesManager.__init__", return_value=None),
         patch("managers.k8s.KubernetesManager.trusted", return_value=True),
     ):
-
         inter = integration_hub_ctx.run(
             integration_hub_ctx.on.relation_changed(s3_relation_tls), state
         )
@@ -148,11 +148,10 @@ def test_s3_relation_connection_ok_tls(
 def test_s3_relation_connection_ko(
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    s3_relation,
-):
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    s3_relation: Relation,
+) -> None:
     state = State(
         relations=[s3_relation],
         containers=[integration_hub_container],
@@ -170,11 +169,11 @@ def test_s3_relation_connection_ko(
 def test_s3_relation_broken(
     exec_calls,
     verify_call,
-    integration_hub_ctx,
-    integration_hub_container,
-    s3_relation,
-    tmp_path,
-):
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    s3_relation: Relation,
+) -> None:
     initial_state = State(
         relations=[s3_relation],
         containers=[integration_hub_container],
@@ -184,7 +183,6 @@ def test_s3_relation_broken(
         patch("managers.k8s.KubernetesManager.__init__", return_value=None),
         patch("managers.k8s.KubernetesManager.trusted", return_value=True),
     ):
-
         state_after_relation_changed = integration_hub_ctx.run(
             integration_hub_ctx.on.relation_changed(s3_relation), initial_state
         )
@@ -207,11 +205,11 @@ def test_azure_storage_relation(
     mock_has_secrets,
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    azure_storage_relation,
-):
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    azure_storage_relation: Relation,
+) -> None:
     state = State(
         relations=[azure_storage_relation],
         containers=[integration_hub_container],
@@ -260,11 +258,11 @@ def test_azure_storage_relation_broken(
     mock_has_secrets,
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    azure_storage_relation,
-):
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    azure_storage_relation: Relation,
+) -> None:
     state = State(
         relations=[azure_storage_relation],
         containers=[integration_hub_container],
@@ -299,12 +297,11 @@ def test_both_azure_storage_and_s3_relation_together(
     mock_has_secrets,
     exec_calls,
     verify_call,
-    tmp_path,
-    integration_hub_ctx,
-    integration_hub_container,
-    s3_relation,
-    azure_storage_relation,
-):
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    s3_relation: Relation,
+    azure_storage_relation: Relation,
+) -> None:
     state = State(
         relations=[s3_relation, azure_storage_relation],
         containers=[integration_hub_container],
@@ -323,8 +320,12 @@ def test_both_azure_storage_and_s3_relation_together(
 
 @patch("workload.IntegrationHub.exec")
 def test_logging_relation_changed(
-    exec_calls, integration_hub_ctx, integration_hub_container, logging_relation, tmp_path
-):
+    exec_calls,
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    logging_relation: Relation,
+) -> None:
     """Test logging relation changed."""
     exp_url = "http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark.svc.cluster.local:3500/loki/api/v1/push"
     state = State(relations=[logging_relation], containers=[integration_hub_container])
@@ -358,8 +359,12 @@ def test_logging_relation_changed(
 
 @patch("workload.IntegrationHub.exec")
 def test_logging_relation_broken(
-    exec_calls, integration_hub_ctx, integration_hub_container, logging_relation, tmp_path
-):
+    exec_calls,
+    tmp_path: Path,
+    integration_hub_ctx: Context,
+    integration_hub_container: Container,
+    logging_relation: Relation,
+) -> None:
     """Test logging relation broken."""
     state = State(relations=[logging_relation], containers=[integration_hub_container])
 


### PR DESCRIPTION
## Changes

- Fix #39 
We now dump the properties in a str instead of assigning the dict to the action result. Despite what the original issue says, the root of the problem was not the dot char, but having capital letters in the props.  
This is why `spark.dynamicAllocation.enabled=true` would show the issue, but not `foo.bar.baz=true`.

- Added a unit test covering this behaviour; as well as a few type hints
