### PR TITLE
[DPE-6481] Add discourse link in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 
 type: charm
+links:
+  documentation: https://discourse.charmhub.io/t/16751
 platforms:
   ubuntu@22.04:amd64:
 # Files implicitly created by charmcraft without a part:
@@ -50,11 +52,11 @@ parts:
     source: .
     after:
       - poetry-deps
-    poetry-export-extra-args: ['--only', 'main,charm-libs']
+    poetry-export-extra-args: ["--only", "main,charm-libs"]
     build-packages:
-      - libffi-dev  # Needed to build Python dependencies with Rust from source
-      - libssl-dev  # Needed to build Python dependencies with Rust from source
-      - pkg-config  # Needed to build Python dependencies with Rust from source
+      - libffi-dev # Needed to build Python dependencies with Rust from source
+      - libssl-dev # Needed to build Python dependencies with Rust from source
+      - pkg-config # Needed to build Python dependencies with Rust from source
     override-build: |
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source


### PR DESCRIPTION
## Changes:
- Added link to new discourse overview [page](https://discourse.charmhub.io/t/integration-hub-for-apache-spark-documentation/16751)

Initial discussions on the content can be found in #43