### PR TITLE
[DPE-6621] Add renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,16 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>canonical/data-platform//renovate_presets/charm.json5',
+  ],
+  reviewers: [
+    'welpaolo',
+    'theoctober19th',
+    'abatisse',
+  ],
+  "schedule": ["after 1am and before 3am on friday"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["after 1am and before 3am on friday"]
+  },
+}


### PR DESCRIPTION
The shared preset is here: https://github.com/canonical/data-platform/blob/main/renovate_presets/charm.json5
It should already play nice with the `charm-lib` group in `pyproject.toml` 