### PR TITLE
[DPE-6757] Update spark job jar version to 3.4.4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,9 +8,9 @@
     "theoctober19th",
     "batalex",
   ],
-  "schedule": ["after 1am and before 3am on friday"],
+  "schedule": ["* 3 * * 5"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 1am and before 3am on friday"]
+    "schedule": ["* 3 * * 5"]
   },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,12 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'github>canonical/data-platform//renovate_presets/charm.json5',
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>canonical/data-platform//renovate_presets/charm.json5",
   ],
-  reviewers: [
-    'welpaolo',
-    'theoctober19th',
-    'batalex',
+  "reviewers": [
+    "welpaolo",
+    "theoctober19th",
+    "batalex",
   ],
   "schedule": ["after 1am and before 3am on friday"],
   "lockFileMaintenance": {

--- a/tests/integration/setup/run_spark_job.sh
+++ b/tests/integration/setup/run_spark_job.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-spark-client.spark-submit -v --username $1 --namespace $2 --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.2.jar 10000
+spark-client.spark-submit -v --username $1 --namespace $2 --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.4.4.jar 10000


### PR DESCRIPTION
# Changes

- Fixed spark job jar version
- Fixed renovate config. Had a chat with Carl, at first, we thought the issue was the unquoted keys, turns out the textual schedule description is dependent on the renovate internal job schedule. This morning the job ran at 0:45, which means that it was not "between 1 and 3". Then a job ran at 5, so it was also outside of the range.
Therefore, we dropped the textual schedule description in favor of a simple cron