### PR TITLE
[DPE-6703] Implement provider side of Spark Service Account Relation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,11 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - main
+      - sa-relation
 
 jobs:
-  ci-tests:
-    uses: ./.github/workflows/ci.yaml
+  # ci-tests:
+  #   uses: ./.github/workflows/ci.yaml
 
   release:
     name: Release charm
@@ -17,9 +17,12 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:
-      channel: latest/edge
+      channel: latest/edge/test
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
+
+
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,3 @@ jobs:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
-
-
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,8 @@ on:
       - sa-relation
 
 jobs:
-  # ci-tests:
-  #   uses: ./.github/workflows/ci.yaml
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
 
   release:
     name: Release charm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - sa-relation
+      - main
 
 jobs:
   ci-tests:
@@ -17,7 +17,7 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:
-      channel: latest/edge/test
+      channel: latest/edge
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .vscode/
+
+# Charm artifacts
+*.charm

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,7 +23,7 @@ parts:
       # Use environment variable instead of `--break-system-packages` to avoid failing on older
       # versions of pip that do not recognize `--break-system-packages`
       # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
-      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==24.3.1  # renovate: charmcraft-pip-latest
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.0.1  # renovate: charmcraft-pip-latest
 
       # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
       curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh  # renovate: charmcraft-uv-latest

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,9 +331,13 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 35
+LIBPATCH = 41
 
 PYDEPS = ["ops>=2.0.0"]
+
+# Starting from what LIBPATCH number to apply legacy solutions
+# v0.17 was the last version without secrets
+LEGACY_SUPPORT_FROM = 17
 
 logger = logging.getLogger(__name__)
 
@@ -351,36 +355,16 @@ REQ_SECRET_FIELDS = "requested-secrets"
 GROUP_MAPPING_FIELD = "secret_group_mapping"
 GROUP_SEPARATOR = "@"
 
-
-class SecretGroup(str):
-    """Secret groups specific type."""
-
-
-class SecretGroupsAggregate(str):
-    """Secret groups with option to extend with additional constants."""
-
-    def __init__(self):
-        self.USER = SecretGroup("user")
-        self.TLS = SecretGroup("tls")
-        self.EXTRA = SecretGroup("extra")
-
-    def __setattr__(self, name, value):
-        """Setting internal constants."""
-        if name in self.__dict__:
-            raise RuntimeError("Can't set constant!")
-        else:
-            super().__setattr__(name, SecretGroup(value))
-
-    def groups(self) -> list:
-        """Return the list of stored SecretGroups."""
-        return list(self.__dict__.values())
-
-    def get_group(self, group: str) -> Optional[SecretGroup]:
-        """If the input str translates to a group name, return that."""
-        return SecretGroup(group) if group in self.groups() else None
+MODEL_ERRORS = {
+    "not_leader": "this unit is not the leader",
+    "no_label_and_uri": "ERROR either URI or label should be used for getting an owned secret but not both",
+    "owner_no_refresh": "ERROR secret owner cannot use --refresh",
+}
 
 
-SECRET_GROUPS = SecretGroupsAggregate()
+##############################################################################
+# Exceptions
+##############################################################################
 
 
 class DataInterfacesError(Exception):
@@ -405,6 +389,19 @@ class SecretsIllegalUpdateError(SecretError):
 
 class IllegalOperationError(DataInterfacesError):
     """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
+
+
+##############################################################################
+# Global helpers / utilities
+##############################################################################
+
+##############################################################################
+# Databag handling and comparison methods
+##############################################################################
 
 
 def get_encoded_dict(
@@ -482,6 +479,11 @@ def diff(event: RelationChangedEvent, bucket: Optional[Union[Unit, Application]]
     return Diff(added, changed, deleted)
 
 
+##############################################################################
+# Module decorators
+##############################################################################
+
+
 def leader_only(f):
     """Decorator to ensure that only leader can perform given operation."""
 
@@ -536,6 +538,36 @@ def either_static_or_dynamic_secrets(f):
     return wrapper
 
 
+def legacy_apply_from_version(version: int) -> Callable:
+    """Decorator to decide whether to apply a legacy function or not.
+
+    Based on LEGACY_SUPPORT_FROM module variable value, the importer charm may only want
+    to apply legacy solutions starting from a specific LIBPATCH.
+
+    NOTE: All 'legacy' functions have to be defined and called in a way that they return `None`.
+    This results in cleaner and more secure execution flows in case the function may be disabled.
+    This requirement implicitly means that legacy functions change the internal state strictly,
+    don't return information.
+    """
+
+    def decorator(f: Callable[..., None]):
+        """Signature is ensuring None return value."""
+        f.legacy_version = version
+
+        def wrapper(self, *args, **kwargs) -> None:
+            if version >= LEGACY_SUPPORT_FROM:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+##############################################################################
+# Helper classes
+##############################################################################
+
+
 class Scope(Enum):
     """Peer relations scope."""
 
@@ -543,16 +575,44 @@ class Scope(Enum):
     UNIT = "unit"
 
 
-################################################################################
-# Secrets internal caching
-################################################################################
+class SecretGroup(str):
+    """Secret groups specific type."""
+
+
+class SecretGroupsAggregate(str):
+    """Secret groups with option to extend with additional constants."""
+
+    def __init__(self):
+        self.USER = SecretGroup("user")
+        self.TLS = SecretGroup("tls")
+        self.EXTRA = SecretGroup("extra")
+
+    def __setattr__(self, name, value):
+        """Setting internal constants."""
+        if name in self.__dict__:
+            raise RuntimeError("Can't set constant!")
+        else:
+            super().__setattr__(name, SecretGroup(value))
+
+    def groups(self) -> list:
+        """Return the list of stored SecretGroups."""
+        return list(self.__dict__.values())
+
+    def get_group(self, group: str) -> Optional[SecretGroup]:
+        """If the input str translates to a group name, return that."""
+        return SecretGroup(group) if group in self.groups() else None
+
+
+SECRET_GROUPS = SecretGroupsAggregate()
 
 
 class CachedSecret:
     """Locally cache a secret.
 
-    The data structure is precisely re-using/simulating as in the actual Secret Storage
+    The data structure is precisely reusing/simulating as in the actual Secret Storage
     """
+
+    KNOWN_MODEL_ERRORS = [MODEL_ERRORS["no_label_and_uri"], MODEL_ERRORS["owner_no_refresh"]]
 
     def __init__(
         self,
@@ -570,6 +630,95 @@ class CachedSecret:
         self.component = component
         self.legacy_labels = legacy_labels
         self.current_label = None
+
+    @property
+    def meta(self) -> Optional[Secret]:
+        """Getting cached secret meta-information."""
+        if not self._secret_meta:
+            if not (self._secret_uri or self.label):
+                return
+
+            try:
+                self._secret_meta = self._model.get_secret(label=self.label)
+            except SecretNotFoundError:
+                # Falling back to seeking for potential legacy labels
+                self._legacy_compat_find_secret_by_old_label()
+
+            # If still not found, to be checked by URI, to be labelled with the proposed label
+            if not self._secret_meta and self._secret_uri:
+                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
+        return self._secret_meta
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on rolling upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see the spec.)
+    # All data involves:
+    #   - databag contents
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Compatibility
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_find_secret_by_old_label(self) -> None:
+        """Compatibility function, allowing to find a secret by a legacy label.
+
+        This functionality is typically needed when secret labels changed over an upgrade.
+        Until the first write operation, we need to maintain data as it was, including keeping
+        the old secret label. In order to keep track of the old label currently used to access
+        the secret, and additional 'current_label' field is being defined.
+        """
+        for label in self.legacy_labels:
+            try:
+                self._secret_meta = self._model.get_secret(label=label)
+            except SecretNotFoundError:
+                pass
+            else:
+                if label != self.label:
+                    self.current_label = label
+                return
+
+    # Migrations
+
+    @legacy_apply_from_version(34)
+    def _legacy_migration_to_new_label_if_needed(self) -> None:
+        """Helper function to re-create the secret with a different label.
+
+        Juju does not provide a way to change secret labels.
+        Thus whenever moving from secrets version that involves secret label changes,
+        we "re-create" the existing secret, and attach the new label to the new
+        secret, to be used from then on.
+
+        Note: we replace the old secret with a new one "in place", as we can't
+        easily switch the containing SecretCache structure to point to a new secret.
+        Instead we are changing the 'self' (CachedSecret) object to point to the
+        new instance.
+        """
+        if not self.current_label or not (self.meta and self._secret_meta):
+            return
+
+        # Create a new secret with the new label
+        content = self._secret_meta.get_content()
+        self._secret_uri = None
+
+        # It will be nice to have the possibility to check if we are the owners of the secret...
+        try:
+            self._secret_meta = self.add_secret(content, label=self.label)
+        except ModelError as err:
+            if MODEL_ERRORS["not_leader"] not in str(err):
+                raise
+        self.current_label = None
+
+    ##########################################################################
+    # Public functions
+    ##########################################################################
 
     def add_secret(
         self,
@@ -593,28 +742,6 @@ class CachedSecret:
         self._secret_meta = secret
         return self._secret_meta
 
-    @property
-    def meta(self) -> Optional[Secret]:
-        """Getting cached secret meta-information."""
-        if not self._secret_meta:
-            if not (self._secret_uri or self.label):
-                return
-
-            for label in [self.label] + self.legacy_labels:
-                try:
-                    self._secret_meta = self._model.get_secret(label=label)
-                except SecretNotFoundError:
-                    pass
-                else:
-                    if label != self.label:
-                        self.current_label = label
-                    break
-
-            # If still not found, to be checked by URI, to be labelled with the proposed label
-            if not self._secret_meta and self._secret_uri:
-                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
-        return self._secret_meta
-
     def get_content(self) -> Dict[str, str]:
         """Getting cached secret content."""
         if not self._secret_content:
@@ -624,42 +751,25 @@ class CachedSecret:
                 except (ValueError, ModelError) as err:
                     # https://bugs.launchpad.net/juju/+bug/2042596
                     # Only triggered when 'refresh' is set
-                    known_model_errors = [
-                        "ERROR either URI or label should be used for getting an owned secret but not both",
-                        "ERROR secret owner cannot use --refresh",
-                    ]
                     if isinstance(err, ModelError) and not any(
-                        msg in str(err) for msg in known_model_errors
+                        msg in str(err) for msg in self.KNOWN_MODEL_ERRORS
                     ):
                         raise
                     # Due to: ValueError: Secret owner cannot use refresh=True
                     self._secret_content = self.meta.get_content()
         return self._secret_content
 
-    def _move_to_new_label_if_needed(self):
-        """Helper function to re-create the secret with a different label."""
-        if not self.current_label or not (self.meta and self._secret_meta):
-            return
-
-        # Create a new secret with the new label
-        old_meta = self._secret_meta
-        content = self._secret_meta.get_content()
-
-        # I wish we could just check if we are the owners of the secret...
-        try:
-            self._secret_meta = self.add_secret(content, label=self.label)
-        except ModelError as err:
-            if "this unit is not the leader" not in str(err):
-                raise
-        old_meta.remove_all_revisions()
-
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
         if not self.meta:
             return
 
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
+            return
+
         if content:
-            self._move_to_new_label_if_needed()
+            self._legacy_migration_to_new_label_if_needed()
             self.meta.set_content(content)
             self._secret_content = content
         else:
@@ -922,6 +1032,23 @@ class Data(ABC):
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         raise NotImplementedError
 
+    # Optional overrides
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """This function should provide a list of compatibility functions to be applied when fetching (legacy) data."""
+        pass
+
+    def _legacy_apply_on_update(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when writing data.
+
+        Since data may be at a legacy version, migration may be mandatory.
+        """
+        pass
+
+    def _legacy_apply_on_delete(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when deleting (legacy) data."""
+        pass
+
     # Internal helper methods
 
     @staticmethod
@@ -1174,6 +1301,16 @@ class Data(ABC):
 
         return relation
 
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Get the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[self.component].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, secret_uri: str) -> None:
+        """Set the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        relation.data[self.component][secret_field] = secret_uri
+
     def fetch_relation_data(
         self,
         relation_ids: Optional[List[int]] = None,
@@ -1190,6 +1327,8 @@ class Data(ABC):
             a dict of the values stored in the relation data bag
                 for all relation instances (indexed by the relation ID).
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
@@ -1228,6 +1367,8 @@ class Data(ABC):
         NOTE: Since only the leader can read the relation's 'this_app'-side
         Application databag, the functionality is limited to leaders
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
@@ -1259,6 +1400,8 @@ class Data(ABC):
     @leader_only
     def update_relation_data(self, relation_id: int, data: dict) -> None:
         """Update the data within the relation."""
+        self._legacy_apply_on_update(list(data.keys()))
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._update_relation_data(relation, data)
@@ -1266,6 +1409,8 @@ class Data(ABC):
     @leader_only
     def delete_relation_data(self, relation_id: int, fields: List[str]) -> None:
         """Remove field from the relation."""
+        self._legacy_apply_on_delete(fields)
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._delete_relation_data(relation, fields)
@@ -1312,6 +1457,8 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
+    RESOURCE_FIELD = "database"
+
     def __init__(
         self,
         model: Model,
@@ -1332,8 +1479,7 @@ class ProviderData(Data):
         uri_to_databag=True,
     ) -> bool:
         """Add a new Juju Secret that will be registered in the relation databag."""
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if uri_to_databag and relation.data[self.component].get(secret_field):
+        if uri_to_databag and self.get_secret_uri(relation, group_mapping):
             logging.error("Secret for relation %s already exists, not adding again", relation.id)
             return False
 
@@ -1344,7 +1490,7 @@ class ProviderData(Data):
 
         # According to lint we may not have a Secret ID
         if uri_to_databag and secret.meta and secret.meta.id:
-            relation.data[self.component][secret_field] = secret.meta.id
+            self.set_secret_uri(relation, group_mapping, secret.meta.id)
 
         # Return the content that was added
         return True
@@ -1445,8 +1591,7 @@ class ProviderData(Data):
         if not relation:
             return
 
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if secret_uri := relation.data[self.local_app].get(secret_field):
+        if secret_uri := self.get_secret_uri(relation, group_mapping):
             return self.secrets.get(label, secret_uri)
 
     def _fetch_specific_relation_data(
@@ -1479,6 +1624,15 @@ class ProviderData(Data):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -1586,7 +1740,7 @@ class RequirerData(Data):
         """
         label = self._generate_secret_label(relation_name, relation_id, group)
 
-        # Fetchin the Secret's meta information ensuring that it's locally getting registered with
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
         CachedSecret(self._model, self.component, label, secret_id).meta
 
     def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
@@ -1599,11 +1753,10 @@ class RequirerData(Data):
 
         for group in SECRET_GROUPS.groups():
             secret_field = self._generate_secret_field_name(group)
-            if secret_field in params_name_list:
-                if secret_uri := relation.data[relation.app].get(secret_field):
-                    self._register_secret_to_relation(
-                        relation.name, relation.id, secret_uri, group
-                    )
+            if secret_field in params_name_list and (
+                secret_uri := self.get_secret_uri(relation, group)
+            ):
+                self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
@@ -1613,6 +1766,17 @@ class RequirerData(Data):
             relation.id, {}
         )
         return bool(data.get("username")) and bool(data.get("password"))
+
+    # Public functions
+
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Getting relation secret URI for the corresponding Secret Group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[relation.app].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, uri: str) -> None:
+        """Setting relation secret URI is not possible for a Requirer."""
+        raise NotImplementedError("Requirer can not change the relation secret URI.")
 
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
@@ -1764,7 +1928,6 @@ class DataPeerData(RequirerData, ProviderData):
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
     ):
-        """Manager of base client relations."""
         RequirerData.__init__(
             self,
             model,
@@ -1775,6 +1938,11 @@ class DataPeerData(RequirerData, ProviderData):
         self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
         self.deleted_label = deleted_label
         self._secret_label_map = {}
+
+        # Legacy information holders
+        self._legacy_labels = []
+        self._legacy_secret_uri = None
+
         # Secrets that are being dynamically added within the scope of this event handler run
         self._new_secrets = []
         self._additional_secret_group_mapping = additional_secret_group_mapping
@@ -1849,10 +2017,12 @@ class DataPeerData(RequirerData, ProviderData):
             value: The string value of the secret
             group_mapping: The name of the "secret group", in case the field is to be added to an existing secret
         """
+        self._legacy_apply_on_update([field])
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if self.secrets_enabled and full_field not in self.current_secret_fields:
             self._new_secrets.append(full_field)
-        if self._no_group_with_databag(field, full_field):
+        if self.valid_field_pattern(field, full_field):
             self.update_relation_data(relation_id, {full_field: value})
 
     # Unlike for set_secret(), there's no harm using this operation with static secrets
@@ -1865,6 +2035,8 @@ class DataPeerData(RequirerData, ProviderData):
         group_mapping: Optional[SecretGroup] = None,
     ) -> Optional[str]:
         """Public interface method to fetch secrets only."""
+        self._legacy_apply_on_fetch()
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if (
             self.secrets_enabled
@@ -1872,7 +2044,7 @@ class DataPeerData(RequirerData, ProviderData):
             and field not in self.current_secret_fields
         ):
             return
-        if self._no_group_with_databag(field, full_field):
+        if self.valid_field_pattern(field, full_field):
             return self.fetch_my_relation_field(relation_id, full_field)
 
     @dynamic_secrets_only
@@ -1883,14 +2055,19 @@ class DataPeerData(RequirerData, ProviderData):
         group_mapping: Optional[SecretGroup] = None,
     ) -> Optional[str]:
         """Public interface method to delete secrets only."""
+        self._legacy_apply_on_delete([field])
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if self.secrets_enabled and full_field not in self.current_secret_fields:
             logger.warning(f"Secret {field} from group {group_mapping} was not found")
             return
-        if self._no_group_with_databag(field, full_field):
+
+        if self.valid_field_pattern(field, full_field):
             self.delete_relation_data(relation_id, [full_field])
 
+    ##########################################################################
     # Helpers
+    ##########################################################################
 
     @staticmethod
     def _field_to_internal_name(field: str, group: Optional[SecretGroup]) -> str:
@@ -1932,10 +2109,69 @@ class DataPeerData(RequirerData, ProviderData):
             if k in self.secret_fields
         }
 
-    # Backwards compatibility
+    def valid_field_pattern(self, field: str, full_field: str) -> bool:
+        """Check that no secret group is attempted to be used together without secrets being enabled.
 
-    def _check_deleted_label(self, relation, fields) -> None:
-        """Helper function for legacy behavior."""
+        Secrets groups are impossible to use with versions that are not yet supporting secrets.
+        """
+        if not self.secrets_enabled and full_field != field:
+            logger.error(
+                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
+            )
+            return False
+        return True
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see spec.)
+    # All data involves:
+    #   - databag
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Full legacy stack for each operation
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """All legacy functions to be applied on fetch."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+
+    def _legacy_apply_on_update(self, fields) -> None:
+        """All legacy functions to be applied on update."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_migration_remove_secret_from_databag(relation, fields)
+        self._legacy_migration_remove_secret_field_name_from_databag(relation)
+
+    def _legacy_apply_on_delete(self, fields) -> None:
+        """All legacy functions to be applied on delete."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_compat_check_deleted_label(relation, fields)
+
+    # Compatibility
+
+    @legacy_apply_from_version(18)
+    def _legacy_compat_check_deleted_label(self, relation, fields) -> None:
+        """Helper function for legacy behavior.
+
+        As long as https://bugs.launchpad.net/juju/+bug/2028094 wasn't fixed,
+        we did not delete fields but rather kept them in the secret with a string value
+        expressing invalidity. This function is maintainnig that behavior when needed.
+        """
+        if not self.deleted_label:
+            return
+
         current_data = self.fetch_my_relation_data([relation.id], fields)
         if current_data is not None:
             # Check if the secret we wanna delete actually exists
@@ -1948,7 +2184,43 @@ class DataPeerData(RequirerData, ProviderData):
                     ", ".join(non_existent),
                 )
 
-    def _remove_secret_from_databag(self, relation, fields: List[str]) -> None:
+    @legacy_apply_from_version(18)
+    def _legacy_compat_secret_uri_from_databag(self, relation) -> None:
+        """Fetching the secret URI from the databag, in case stored there."""
+        self._legacy_secret_uri = relation.data[self.component].get(
+            self._generate_secret_field_name(), None
+        )
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_generate_prev_labels(self) -> None:
+        """Generator for legacy secret label names, for backwards compatibility.
+
+        Secret label is part of the data that MUST be maintained across rolling upgrades.
+        In case there may be a change on a secret label, the old label must be recognized
+        after upgrades, and left intact until the first write operation -- when we roll over
+        to the new label.
+
+        This function keeps "memory" of previously used secret labels.
+        NOTE: Return value takes decorator into account -- all 'legacy' functions may return `None`
+
+        v0.34 (rev69): Fixing issue https://github.com/canonical/data-platform-libs/issues/155
+                       meant moving from '<app_name>.<scope>' (i.e. 'mysql.app', 'mysql.unit')
+                       to labels '<relation_name>.<app_name>.<scope>' (like 'peer.mysql.app')
+        """
+        if self._legacy_labels:
+            return
+
+        result = []
+        members = [self._model.app.name]
+        if self.scope:
+            members.append(self.scope.value)
+        result.append(f"{'.'.join(members)}")
+        self._legacy_labels = result
+
+    # Migration
+
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_from_databag(self, relation, fields: List[str]) -> None:
         """For Rolling Upgrades -- when moving from databag to secrets usage.
 
         Practically what happens here is to remove stuff from the databag that is
@@ -1962,10 +2234,16 @@ class DataPeerData(RequirerData, ProviderData):
             if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
                 self._delete_relation_data_without_secrets(self.component, relation, [field])
 
-    def _remove_secret_field_name_from_databag(self, relation) -> None:
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_field_name_from_databag(self, relation) -> None:
         """Making sure that the old databag URI is gone.
 
         This action should not be executed more than once.
+
+        There was a phase (before moving secrets usage to libs) when charms saved the peer
+        secret URI to the databag, and used this URI from then on to retrieve their secret.
+        When upgrading to charm versions using this library, we need to add a label to the
+        secret and access it via label from than on, and remove the old traces from the databag.
         """
         # Nothing to do if 'internal-secret' is not in the databag
         if not (relation.data[self.component].get(self._generate_secret_field_name())):
@@ -1981,25 +2259,9 @@ class DataPeerData(RequirerData, ProviderData):
             # Databag reference to the secret URI can be removed, now that it's labelled
             relation.data[self.component].pop(self._generate_secret_field_name(), None)
 
-    def _previous_labels(self) -> List[str]:
-        """Generator for legacy secret label names, for backwards compatibility."""
-        result = []
-        members = [self._model.app.name]
-        if self.scope:
-            members.append(self.scope.value)
-        result.append(f"{'.'.join(members)}")
-        return result
-
-    def _no_group_with_databag(self, field: str, full_field: str) -> bool:
-        """Check that no secret group is attempted to be used together with databag."""
-        if not self.secrets_enabled and full_field != field:
-            logger.error(
-                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
-            )
-            return False
-        return True
-
+    ##########################################################################
     # Event handlers
+    ##########################################################################
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
@@ -2009,7 +2271,9 @@ class DataPeerData(RequirerData, ProviderData):
         """Event emitted when the secret has changed."""
         pass
 
+    ##########################################################################
     # Overrides of Relation Data handling functions
+    ##########################################################################
 
     def _generate_secret_label(
         self, relation_name: str, relation_id: int, group_mapping: SecretGroup
@@ -2046,13 +2310,14 @@ class DataPeerData(RequirerData, ProviderData):
             return
 
         label = self._generate_secret_label(relation_name, relation_id, group_mapping)
-        secret_uri = relation.data[self.component].get(self._generate_secret_field_name(), None)
 
         # URI or legacy label is only to applied when moving single legacy secret to a (new) label
         if group_mapping == SECRET_GROUPS.EXTRA:
             # Fetching the secret with fallback to URI (in case label is not yet known)
             # Label would we "stuck" on the secret in case it is found
-            return self.secrets.get(label, secret_uri, legacy_labels=self._previous_labels())
+            return self.secrets.get(
+                label, self._legacy_secret_uri, legacy_labels=self._legacy_labels
+            )
         return self.secrets.get(label)
 
     def _get_group_secret_contents(
@@ -2082,7 +2347,6 @@ class DataPeerData(RequirerData, ProviderData):
     @either_static_or_dynamic_secrets
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        self._remove_secret_from_databag(relation, list(data.keys()))
         _, normal_fields = self._process_secret_fields(
             relation,
             self.secret_fields,
@@ -2091,7 +2355,6 @@ class DataPeerData(RequirerData, ProviderData):
             data=data,
             uri_to_databag=False,
         )
-        self._remove_secret_field_name_from_databag(relation)
 
         normal_content = {k: v for k, v in data.items() if k in normal_fields}
         self._update_relation_data_without_secrets(self.component, relation, normal_content)
@@ -2100,9 +2363,6 @@ class DataPeerData(RequirerData, ProviderData):
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         if self.secret_fields and self.deleted_label:
-            # Legacy, backwards compatibility
-            self._check_deleted_label(relation, fields)
-
             _, normal_fields = self._process_secret_fields(
                 relation,
                 self.secret_fields,
@@ -2137,7 +2397,9 @@ class DataPeerData(RequirerData, ProviderData):
             "fetch_my_relation_data() and fetch_my_relation_field()"
         )
 
+    ##########################################################################
     # Public functions -- inherited
+    ##########################################################################
 
     fetch_my_relation_data = Data.fetch_my_relation_data
     fetch_my_relation_field = Data.fetch_my_relation_field
@@ -2309,7 +2571,7 @@ class RelationEventWithSecret(RelationEvent):
         return self._cached_secrets
 
     def _get_secret(self, group) -> Optional[Dict[str, str]]:
-        """Retrieveing secrets."""
+        """Retrieving secrets."""
         if not self.app:
             return
         if not self._secrets.get(group):
@@ -2602,6 +2864,14 @@ class DatabaseProviderData(ProviderData):
         """
         self.update_relation_data(relation_id, {"version": version})
 
+    def set_subordinated(self, relation_id: int) -> None:
+        """Raises the subordinated flag in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        self.update_relation_data(relation_id, {"subordinated": "true"})
+
 
 class DatabaseProviderEventHandlers(EventHandlers):
     """Provider-side of the database relation handlers."""
@@ -2838,6 +3108,21 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
+        is_subordinate = False
+        remote_unit_data = None
+        for key in event.relation.data.keys():
+            if isinstance(key, Unit) and not key.name.startswith(self.charm.app.name):
+                remote_unit_data = event.relation.data[key]
+            elif isinstance(key, Application) and key.name != self.charm.app.name:
+                is_subordinate = event.relation.data[key].get("subordinated") == "true"
+
+        if is_subordinate:
+            if not remote_unit_data:
+                return
+
+            if remote_unit_data.get("state") != "ready":
+                return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
@@ -3018,6 +3303,8 @@ class KafkaRequiresEvents(CharmEvents):
 
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
+
+    RESOURCE_FIELD = "topic"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
@@ -3267,6 +3554,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
+
+    RESOURCE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ from events.azure_storage import AzureStorageEvents
 from events.configuration_actions import ConfigurationActionEvents
 from events.integration_hub import IntegrationHubEvents
 from events.logging import LoggingEvents
-from events.provider import IntegrationHubProviderEvents
+from events.provider import SparkServiceAccountProviderEvents
 from events.pushgateway import PushgatewayEvents
 from events.s3 import S3Events
 from workload import IntegrationHub
@@ -35,7 +35,7 @@ class SparkIntegrationHub(CharmBase, WithLogging):
         self.s3 = S3Events(self, context, workload)
         self.azure_storage = AzureStorageEvents(self, context, workload)
         self.configuration_action_events = ConfigurationActionEvents(self, context, workload)
-        self.sa = IntegrationHubProviderEvents(self, context, workload)
+        self.sa = SparkServiceAccountProviderEvents(self, context, workload)
         self.pushgateway = PushgatewayEvents(self, context, workload)
         self.integration_hub = IntegrationHubEvents(self, context, workload)
         self.logging = LoggingEvents(self, context, workload)

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -56,36 +56,15 @@ class Context(WithLogging):
     # --- RELATIONS ---
     # -----------------
 
-    # @property
-    # def _s3_relation_id(self) -> int | None:
-    #     """The S3 relation."""
-    #     return (
-    #         relation.id if (relation := self.charm.model.get_relation(S3_RELATION_NAME)) else None
-    #     )
-
     @property
     def _s3_relation(self) -> Relation | None:
         """The S3 relation."""
         return self.charm.model.get_relation(S3_RELATION_NAME)
 
-    # @property
-    # def _azure_storage_relation_id(self) -> int | None:
-    #     """The Azure Storage relation ID."""
-    #     return (
-    #         relation.id
-    #         if (relation := self.charm.model.get_relation(AZURE_RELATION_NAME))
-    #         else None
-    #     )
-
     @property
     def _azure_storage_relation(self) -> Relation | None:
         """The Azure Storage relation."""
         return self.charm.model.get_relation(AZURE_RELATION_NAME)
-
-    # @property
-    # def _pushgateway_relation_id(self) -> int | None:
-    #     """The Pushgateway relation."""
-    #     return relation.id if (relation := self.charm.model.get_relation(PUSHGATEWAY)) else None
 
     @property
     def _pushgateway_relation(self) -> Relation | None:

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -27,6 +27,7 @@ from core.domain import (
     S3ConnectionInfo,
     ServiceAccount,
 )
+from relations.spark_sa import IntegrationHubProviderData
 
 
 class Context(WithLogging):
@@ -41,6 +42,9 @@ class Context(WithLogging):
         self.azure_storage_endpoint = RequirerData(
             self.charm.model, AZURE_RELATION_NAME, additional_secret_fields=["secret-key"]
         )
+        self.integration_hub_provider_data = IntegrationHubProviderData(
+            self.model, INTEGRATION_HUB_REL
+        )
 
     # --------------
     # --- CONFIG ---
@@ -52,41 +56,46 @@ class Context(WithLogging):
     # --- RELATIONS ---
     # -----------------
 
-    @property
-    def _s3_relation_id(self) -> int | None:
-        """The S3 relation."""
-        return (
-            relation.id if (relation := self.charm.model.get_relation(S3_RELATION_NAME)) else None
-        )
+    # @property
+    # def _s3_relation_id(self) -> int | None:
+    #     """The S3 relation."""
+    #     return (
+    #         relation.id if (relation := self.charm.model.get_relation(S3_RELATION_NAME)) else None
+    #     )
 
     @property
     def _s3_relation(self) -> Relation | None:
         """The S3 relation."""
         return self.charm.model.get_relation(S3_RELATION_NAME)
 
-    @property
-    def _azure_storage_relation_id(self) -> int | None:
-        """The Azure Storage relation ID."""
-        return (
-            relation.id
-            if (relation := self.charm.model.get_relation(AZURE_RELATION_NAME))
-            else None
-        )
+    # @property
+    # def _azure_storage_relation_id(self) -> int | None:
+    #     """The Azure Storage relation ID."""
+    #     return (
+    #         relation.id
+    #         if (relation := self.charm.model.get_relation(AZURE_RELATION_NAME))
+    #         else None
+    #     )
 
     @property
     def _azure_storage_relation(self) -> Relation | None:
         """The Azure Storage relation."""
         return self.charm.model.get_relation(AZURE_RELATION_NAME)
 
-    @property
-    def _pushgateway_relation_id(self) -> int | None:
-        """The Pushgateway relation."""
-        return relation.id if (relation := self.charm.model.get_relation(PUSHGATEWAY)) else None
+    # @property
+    # def _pushgateway_relation_id(self) -> int | None:
+    #     """The Pushgateway relation."""
+    #     return relation.id if (relation := self.charm.model.get_relation(PUSHGATEWAY)) else None
 
     @property
     def _pushgateway_relation(self) -> Relation | None:
         """The Pushgateway relation."""
         return self.charm.model.get_relation(PUSHGATEWAY)
+
+    @property
+    def _spark_service_account_relation(self) -> Relation | None:
+        """The Spark service account relation."""
+        return self.charm.model.get_relation(INTEGRATION_HUB_REL)
 
     # --- DOMAIN OBJECTS ---
 
@@ -99,7 +108,7 @@ class Context(WithLogging):
     def azure_storage(self) -> AzureStorageConnectionInfo | None:
         """The server state of the current running Unit."""
         relation_data = (
-            self.azure_storage_endpoint.fetch_relation_data()[self._azure_storage_relation_id]
+            self.azure_storage_endpoint.fetch_relation_data()[self._azure_storage_relation.id]
             if self._azure_storage_relation
             else None
         )
@@ -126,20 +135,19 @@ class Context(WithLogging):
         return set(self.model.relations[INTEGRATION_HUB_REL])
 
     @property
-    def services_accounts(self) -> List[ServiceAccount]:
+    def service_accounts(self) -> List[ServiceAccount]:
         """Retrieve  service account managed by relations.
 
         Returns:
             List of service accounts/namespaces managed by the Integration Hub
         """
         return [
-            ServiceAccount(relation, relation.app)
+            ServiceAccount(self.integration_hub_provider_data, relation.id)
             for relation in self.client_relations
-            if not relation or not relation.app
         ]
 
     @property
-    def loki_url(self) -> str | None:
+    def loki_url(self) -> LokiURL | None:
         """Retrieve Loki URL from logging relations."""
         if relation := self.charm.model.get_relation(LOGGING_RELATION_NAME):
             if units := list(relation.units):

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -42,7 +42,7 @@ class Context(WithLogging):
         self.azure_storage_endpoint = RequirerData(
             self.charm.model, AZURE_RELATION_NAME, additional_secret_fields=["secret-key"]
         )
-        self.integration_hub_provider_data = SparkServiceAccountProviderData(
+        self.spark_service_account_provider_data = SparkServiceAccountProviderData(
             self.model, INTEGRATION_HUB_REL
         )
 
@@ -71,10 +71,6 @@ class Context(WithLogging):
         """The Pushgateway relation."""
         return self.charm.model.get_relation(PUSHGATEWAY)
 
-    @property
-    def _spark_service_account_relation(self) -> Relation | None:
-        """The Spark service account relation."""
-        return self.charm.model.get_relation(INTEGRATION_HUB_REL)
 
     # --- DOMAIN OBJECTS ---
 
@@ -121,7 +117,7 @@ class Context(WithLogging):
             List of service accounts/namespaces managed by the Integration Hub
         """
         return [
-            ServiceAccount(self.integration_hub_provider_data, relation.id)
+            ServiceAccount(self.spark_service_account_provider_data, relation.id)
             for relation in self.client_relations
         ]
 

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -71,7 +71,6 @@ class Context(WithLogging):
         """The Pushgateway relation."""
         return self.charm.model.get_relation(PUSHGATEWAY)
 
-
     # --- DOMAIN OBJECTS ---
 
     @property

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -27,7 +27,7 @@ from core.domain import (
     S3ConnectionInfo,
     ServiceAccount,
 )
-from relations.spark_sa import IntegrationHubProviderData
+from relations.spark_sa import SparkServiceAccountProviderData
 
 
 class Context(WithLogging):
@@ -42,7 +42,7 @@ class Context(WithLogging):
         self.azure_storage_endpoint = RequirerData(
             self.charm.model, AZURE_RELATION_NAME, additional_secret_fields=["secret-key"]
         )
-        self.integration_hub_provider_data = IntegrationHubProviderData(
+        self.integration_hub_provider_data = SparkServiceAccountProviderData(
             self.model, INTEGRATION_HUB_REL
         )
 

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -11,7 +11,7 @@ from typing import List, MutableMapping
 from ops import Application, Relation, Unit
 
 from common.utils import DotSerializer
-from relations.spark_sa import IntegrationHubProviderData
+from relations.spark_sa import SparkServiceAccountProviderData
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ class HubConfiguration(StateBase):
 class ServiceAccount:
     """Class representing the service account managed by the Spark Integration Hub charm."""
 
-    def __init__(self, relation_data: IntegrationHubProviderData, relation_id: int):
+    def __init__(self, relation_data: SparkServiceAccountProviderData, relation_id: int):
         self.relation_data = relation_data
         self.relation_id = relation_id
 

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -228,31 +228,20 @@ class ServiceAccount:
         )
 
     @property
-    def namespace(self) -> str | None:
-        """Return the used namespace."""
-        return self.relation_data.fetch_my_relation_field(
-            relation_id=self.relation_id, field="namespace"
-        )
-
-    @property
     def spark_properties(self) -> dict[str, str] | None:
         """Return the set of Spark properties."""
-        field_data = (
-            self.relation_data.fetch_my_relation_field(
-                relation_id=self.relation_id, field="spark-properties"
-            )
-            or "{}"
+        field_data = self.relation_data.fetch_my_relation_field(
+            relation_id=self.relation_id, field="spark-properties"
         )
+        if field_data is None:
+            return None
+
         props = dict(json.loads(field_data))
         return dict(sorted(props.items()))
 
     def set_service_account(self, service_account: str) -> None:
         """Set the service account name."""
         self.relation_data.set_service_account(self.relation_id, service_account)
-
-    def set_namespace(self, namespace: str) -> str | None:
-        """Set namespace relation field for this service account."""
-        self.relation_data.set_namespace(self.relation_id, namespace)
 
     def set_spark_properties(self, spark_properties: dict[str, str]) -> None:
         """Set spark-properties relation field for this service account."""

--- a/src/events/azure_storage.py
+++ b/src/events/azure_storage.py
@@ -28,7 +28,7 @@ class AzureStorageEvents(BaseEventHandler, WithLogging):
         self.context = context
         self.workload = workload
 
-        self.integration_hub = IntegrationHubManager(self.workload)
+        self.integration_hub = IntegrationHubManager(self.workload, self.context)
 
         self.azure_storage_requirer = AzureStorageRequires(
             self.charm, self.context.azure_storage_endpoint.relation_name
@@ -47,25 +47,13 @@ class AzureStorageEvents(BaseEventHandler, WithLogging):
     def _on_azure_storage_connection_info_changed(self, _: StorageConnectionInfoChangedEvent):
         """Handle the `StorageConnectionInfoChangedEvent` event from Object Storage integrator."""
         self.logger.info("Azure Storage connection info changed")
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update()
 
     @defer_when_not_ready
     def _on_azure_storage_connection_info_gone(self, _: StorageConnectionInfoGoneEvent):
         """Handle the `StorageConnectionInfoGoneEvent` event for Object Storage integrator."""
         self.logger.info("Azure Storage connection info gone")
-        self.integration_hub.update(
-            self.context.s3,
-            None,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update(set_azure_storage_none=True)
 
         self.charm.unit.status = self.get_app_status(
             self.context.s3, None, self.context.pushgateway

--- a/src/events/integration_hub.py
+++ b/src/events/integration_hub.py
@@ -23,7 +23,7 @@ class IntegrationHubEvents(BaseEventHandler, WithLogging):
         self.context = context
         self.workload = workload
 
-        self.integration_hub = IntegrationHubManager(self.workload)
+        self.integration_hub = IntegrationHubManager(self.workload, self.context)
 
         self.framework.observe(
             self.charm.on.integration_hub_pebble_ready,
@@ -46,25 +46,13 @@ class IntegrationHubEvents(BaseEventHandler, WithLogging):
     @defer_when_not_ready
     def _on_integration_hub_pebble_ready(self, _):
         """Handle on Pebble ready event."""
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update()
 
     @compute_status
     @defer_when_not_ready
     def _on_peer_relation_changed(self, _):
         """Handle on PEER relation changed event."""
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update()
 
     @compute_status
     def _update_event(self, _):

--- a/src/events/logging.py
+++ b/src/events/logging.py
@@ -35,29 +35,17 @@ class LoggingEvents(BaseEventHandler, WithLogging):
         )
 
         # define integration hub manager
-        self.integration_hub = IntegrationHubManager(self.workload)
+        self.integration_hub = IntegrationHubManager(self.workload, self.context)
 
     @compute_status
     @defer_when_not_ready
     def _on_update_loki_url(self, _: RelationChangedEvent):
         """Handle the `LoggingChangedEvent` event."""
         self.logger.info("Logging changed")
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update()
 
     @defer_when_not_ready
     def _on_remove_loki_url(self, _: RelationBrokenEvent):
         """Handle the `LoggingBrokenEvent` event."""
         self.logger.info("Logging removed")
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            None,
-        )
+        self.integration_hub.update(set_loki_url_none=True)

--- a/src/events/provider.py
+++ b/src/events/provider.py
@@ -11,6 +11,7 @@ from constants import INTEGRATION_HUB_REL
 from core.context import Context
 from core.workload import IntegrationHubWorkloadBase
 from events.base import BaseEventHandler, defer_when_not_ready
+from managers.integration_hub import IntegrationHubManager
 from relations.spark_sa import (
     IntegrationHubProvider,
     ServiceAccountReleasedEvent,
@@ -29,6 +30,8 @@ class IntegrationHubProviderEvents(BaseEventHandler, WithLogging):
         self.workload = workload
 
         self.sa = IntegrationHubProvider(self.charm, INTEGRATION_HUB_REL)
+        self.integration_hub = IntegrationHubManager(self.workload, self.context)
+
         self.framework.observe(self.sa.on.account_requested, self._on_service_account_requested)
         self.framework.observe(self.sa.on.account_released, self._on_service_account_released)
 
@@ -60,6 +63,7 @@ class IntegrationHubProviderEvents(BaseEventHandler, WithLogging):
 
         self.sa.set_service_account(relation_id, service_account)  # type: ignore
         self.sa.set_namespace(relation_id, namespace)  # type: ignore
+        self.integration_hub.update()
 
     @defer_when_not_ready
     def _on_service_account_released(self, event: ServiceAccountReleasedEvent):

--- a/src/events/s3.py
+++ b/src/events/s3.py
@@ -12,10 +12,12 @@ from charms.data_platform_libs.v0.s3 import (
 from ops import CharmBase
 
 from common.utils import WithLogging
+from constants import INTEGRATION_HUB_REL
 from core.context import Context
 from core.workload import IntegrationHubWorkloadBase
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.integration_hub import IntegrationHubManager
+from relations.spark_sa import IntegrationHubProviderData
 
 
 class S3Events(BaseEventHandler, WithLogging):
@@ -28,7 +30,10 @@ class S3Events(BaseEventHandler, WithLogging):
         self.context = context
         self.workload = workload
 
-        self.integration_hub = IntegrationHubManager(self.workload)
+        self.integration_hub_provider_data = IntegrationHubProviderData(
+            self.charm.model, INTEGRATION_HUB_REL
+        )
+        self.integration_hub = IntegrationHubManager(self.workload, self.context)
 
         self.s3_requirer = S3Requirer(self.charm, self.context.s3_endpoint.relation_name)
         self.framework.observe(
@@ -41,25 +46,13 @@ class S3Events(BaseEventHandler, WithLogging):
     def _on_s3_credential_changed(self, _: CredentialsChangedEvent):
         """Handle the `CredentialsChangedEvent` event from S3 integrator."""
         self.logger.info("S3 Credentials changed")
-        self.integration_hub.update(
-            self.context.s3,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update()
 
     @defer_when_not_ready
     def _on_s3_credential_gone(self, _: CredentialsGoneEvent):
         """Handle the `CredentialsGoneEvent` event for S3 integrator."""
         self.logger.info("S3 Credentials gone")
-        self.integration_hub.update(
-            None,
-            self.context.azure_storage,
-            self.context.pushgateway,
-            self.context.hub_configurations,
-            self.context.loki_url,
-        )
+        self.integration_hub.update(set_s3_none=True)
 
         self.charm.unit.status = self.get_app_status(
             None, self.context.azure_storage, self.context.pushgateway

--- a/src/events/s3.py
+++ b/src/events/s3.py
@@ -12,12 +12,10 @@ from charms.data_platform_libs.v0.s3 import (
 from ops import CharmBase
 
 from common.utils import WithLogging
-from constants import INTEGRATION_HUB_REL
 from core.context import Context
 from core.workload import IntegrationHubWorkloadBase
 from events.base import BaseEventHandler, compute_status, defer_when_not_ready
 from managers.integration_hub import IntegrationHubManager
-from relations.spark_sa import IntegrationHubProviderData
 
 
 class S3Events(BaseEventHandler, WithLogging):
@@ -30,9 +28,6 @@ class S3Events(BaseEventHandler, WithLogging):
         self.context = context
         self.workload = workload
 
-        self.integration_hub_provider_data = IntegrationHubProviderData(
-            self.charm.model, INTEGRATION_HUB_REL
-        )
         self.integration_hub = IntegrationHubManager(self.workload, self.context)
 
         self.s3_requirer = S3Requirer(self.charm, self.context.s3_endpoint.relation_name)

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -195,6 +195,7 @@ class IntegrationHubManager(WithLogging):
         azure_storage = None if set_azure_storage_none else self.context.azure_storage
         pushgateway = None if set_pushgateway_none else self.context.pushgateway
         loki_url = None if set_loki_url_none else self.context.loki_url
+        hub_conf = self.context.hub_configurations
 
         self.logger.debug("Update")
         self.workload.stop()

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -178,7 +178,6 @@ class IntegrationHubManager(WithLogging):
         self.logger.debug(f"{existing_content=}")
         self.logger.debug(f"{content=}")
         if not file_exists or existing_content != content:
-            self.logger.warning("File was written.")
             self.workload.write(content, file_path)
             return True
 
@@ -213,11 +212,7 @@ class IntegrationHubManager(WithLogging):
             )
             self.workload.restart()
 
-        self.logger.warning("service acccounts are")
-        self.logger.warning(self.context.service_accounts)
-
-        for sa in self.context.service_accounts:
-            self.logger.warning(sa.spark_properties)
-            self.logger.warning(config.to_dict())
-            if sa.spark_properties != config.to_dict():
-                sa.set_spark_properties(config.to_dict())
+        if self.context.charm.unit.is_leader():
+            for sa in self.context.service_accounts:
+                if sa.spark_properties != config.to_dict():
+                    sa.set_spark_properties(config.to_dict())

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -188,14 +188,12 @@ class IntegrationHubManager(WithLogging):
         set_s3_none: bool = False,
         set_azure_storage_none: bool = False,
         set_pushgateway_none: bool = False,
-        set_hub_conf_none: bool = False,
         set_loki_url_none: bool = False,
     ) -> None:
         """Update the Integration Hub service if needed."""
         s3 = None if set_s3_none else self.context.s3
         azure_storage = None if set_azure_storage_none else self.context.azure_storage
         pushgateway = None if set_pushgateway_none else self.context.pushgateway
-        hub_conf = None if set_hub_conf_none else self.context.hub_configurations
         loki_url = None if set_loki_url_none else self.context.loki_url
 
         self.logger.debug("Update")

--- a/src/relations/spark_sa.py
+++ b/src/relations/spark_sa.py
@@ -23,6 +23,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     SECRET_GROUPS,
     EventHandlers,
     ProviderData,
+    RelationEventWithSecret,
     RequirerData,
     RequirerEventHandlers,
 )
@@ -132,11 +133,16 @@ class ServiceAccountGoneEvent(RelationEvent):
     """Event emitted when service account are removed from this relation."""
 
 
+class ServiceAccountPropertyChangedEvent(RelationEventWithSecret):
+    """Event emitted when Spark properties for the service account are changed in this relation."""
+
+
 class SparkServiceAccountRequirerEvents(ObjectEvents):
     """Event descriptor for events raised by the Requirer."""
 
     account_granted = EventSource(ServiceAccountGrantedEvent)
     account_gone = EventSource(ServiceAccountGoneEvent)
+    properties_changed = EventSource(ServiceAccountPropertyChangedEvent)
 
 
 class SparkServiceAccountProviderData(ProviderData):
@@ -268,9 +274,27 @@ class SparkServiceAccountRequirerEventHandlers(RequirerEventHandlers):
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
-    def _on_secret_changed_event(self, _: SecretChangedEvent):
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
         """Event notifying about a new value of a secret."""
-        pass
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        getattr(self.on, "properties_changed").emit(relation, app=relation.app, unit=remote_unit)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the Spark Service Account relation has changed."""

--- a/src/relations/spark_sa.py
+++ b/src/relations/spark_sa.py
@@ -46,6 +46,7 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+SPARK_PROPERTIES_RELATION_FIELD = "spark-properties"
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +152,8 @@ class IntegrationHubRequirerEvents(ObjectEvents):
 class IntegrationHubProviderData(ProviderData):
     """Provider-side of the Spark Integration Hub relation."""
 
+    RESOURCE_FIELD = "service-account"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -164,13 +167,22 @@ class IntegrationHubProviderData(ProviderData):
         self.update_relation_data(relation_id, {"service-account": service_account})
 
     def set_namespace(self, relation_id: int, namespace: str) -> None:
-        """Set the bootstrap server in the application relation databag.
+        """Set the namespace in the application relation databag.
 
         Args:
             relation_id: the identifier for a particular relation.
             namespace: the namespace name.
         """
         self.update_relation_data(relation_id, {"namespace": namespace})
+
+    def set_spark_properties(self, relation_id: int, spark_properties: str) -> None:
+        """Set the Spark properties in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            spark_properties: the dictionary that contains key-value for Spark properties.
+        """
+        self.update_relation_data(relation_id, {SPARK_PROPERTIES_RELATION_FIELD: spark_properties})
 
 
 class IntegrationHubProviderEventHandlers(EventHandlers):
@@ -229,6 +241,10 @@ class IntegrationHubRequirerData(RequirerData):
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of Integration Hub relations."""
+        if not additional_secret_fields:
+            additional_secret_fields = []
+        if SPARK_PROPERTIES_RELATION_FIELD not in additional_secret_fields:
+            additional_secret_fields.append(SPARK_PROPERTIES_RELATION_FIELD)
         super().__init__(model, relation_name, additional_secret_fields=additional_secret_fields)
         self.service_account = service_account
         self.namespace = namespace
@@ -300,7 +316,9 @@ class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
         secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
 
         if (
-            "service-account" in diff.added and "namespace" in diff.added
+            "service-account" in diff.added
+            and "namespace" in diff.added
+            and "spark-properties" in diff.added
         ) or secret_field_user in diff.added:
             getattr(self.on, "account_granted").emit(
                 event.relation, app=event.app, unit=event.unit

--- a/tests/integration/app-charm/actions.yaml
+++ b/tests/integration/app-charm/actions.yaml
@@ -1,0 +1,8 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+get-properties-sa1:
+  description: Get Spark properties for the service account sa1
+
+get-properties-sa2:
+  description: Get Spark properties for the service account sa2

--- a/tests/integration/app-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/tests/integration/app-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,9 +331,13 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 35
+LIBPATCH = 41
 
 PYDEPS = ["ops>=2.0.0"]
+
+# Starting from what LIBPATCH number to apply legacy solutions
+# v0.17 was the last version without secrets
+LEGACY_SUPPORT_FROM = 17
 
 logger = logging.getLogger(__name__)
 
@@ -351,36 +355,16 @@ REQ_SECRET_FIELDS = "requested-secrets"
 GROUP_MAPPING_FIELD = "secret_group_mapping"
 GROUP_SEPARATOR = "@"
 
-
-class SecretGroup(str):
-    """Secret groups specific type."""
-
-
-class SecretGroupsAggregate(str):
-    """Secret groups with option to extend with additional constants."""
-
-    def __init__(self):
-        self.USER = SecretGroup("user")
-        self.TLS = SecretGroup("tls")
-        self.EXTRA = SecretGroup("extra")
-
-    def __setattr__(self, name, value):
-        """Setting internal constants."""
-        if name in self.__dict__:
-            raise RuntimeError("Can't set constant!")
-        else:
-            super().__setattr__(name, SecretGroup(value))
-
-    def groups(self) -> list:
-        """Return the list of stored SecretGroups."""
-        return list(self.__dict__.values())
-
-    def get_group(self, group: str) -> Optional[SecretGroup]:
-        """If the input str translates to a group name, return that."""
-        return SecretGroup(group) if group in self.groups() else None
+MODEL_ERRORS = {
+    "not_leader": "this unit is not the leader",
+    "no_label_and_uri": "ERROR either URI or label should be used for getting an owned secret but not both",
+    "owner_no_refresh": "ERROR secret owner cannot use --refresh",
+}
 
 
-SECRET_GROUPS = SecretGroupsAggregate()
+##############################################################################
+# Exceptions
+##############################################################################
 
 
 class DataInterfacesError(Exception):
@@ -405,6 +389,19 @@ class SecretsIllegalUpdateError(SecretError):
 
 class IllegalOperationError(DataInterfacesError):
     """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
+
+
+##############################################################################
+# Global helpers / utilities
+##############################################################################
+
+##############################################################################
+# Databag handling and comparison methods
+##############################################################################
 
 
 def get_encoded_dict(
@@ -482,6 +479,11 @@ def diff(event: RelationChangedEvent, bucket: Optional[Union[Unit, Application]]
     return Diff(added, changed, deleted)
 
 
+##############################################################################
+# Module decorators
+##############################################################################
+
+
 def leader_only(f):
     """Decorator to ensure that only leader can perform given operation."""
 
@@ -536,6 +538,36 @@ def either_static_or_dynamic_secrets(f):
     return wrapper
 
 
+def legacy_apply_from_version(version: int) -> Callable:
+    """Decorator to decide whether to apply a legacy function or not.
+
+    Based on LEGACY_SUPPORT_FROM module variable value, the importer charm may only want
+    to apply legacy solutions starting from a specific LIBPATCH.
+
+    NOTE: All 'legacy' functions have to be defined and called in a way that they return `None`.
+    This results in cleaner and more secure execution flows in case the function may be disabled.
+    This requirement implicitly means that legacy functions change the internal state strictly,
+    don't return information.
+    """
+
+    def decorator(f: Callable[..., None]):
+        """Signature is ensuring None return value."""
+        f.legacy_version = version
+
+        def wrapper(self, *args, **kwargs) -> None:
+            if version >= LEGACY_SUPPORT_FROM:
+                return f(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+##############################################################################
+# Helper classes
+##############################################################################
+
+
 class Scope(Enum):
     """Peer relations scope."""
 
@@ -543,16 +575,44 @@ class Scope(Enum):
     UNIT = "unit"
 
 
-################################################################################
-# Secrets internal caching
-################################################################################
+class SecretGroup(str):
+    """Secret groups specific type."""
+
+
+class SecretGroupsAggregate(str):
+    """Secret groups with option to extend with additional constants."""
+
+    def __init__(self):
+        self.USER = SecretGroup("user")
+        self.TLS = SecretGroup("tls")
+        self.EXTRA = SecretGroup("extra")
+
+    def __setattr__(self, name, value):
+        """Setting internal constants."""
+        if name in self.__dict__:
+            raise RuntimeError("Can't set constant!")
+        else:
+            super().__setattr__(name, SecretGroup(value))
+
+    def groups(self) -> list:
+        """Return the list of stored SecretGroups."""
+        return list(self.__dict__.values())
+
+    def get_group(self, group: str) -> Optional[SecretGroup]:
+        """If the input str translates to a group name, return that."""
+        return SecretGroup(group) if group in self.groups() else None
+
+
+SECRET_GROUPS = SecretGroupsAggregate()
 
 
 class CachedSecret:
     """Locally cache a secret.
 
-    The data structure is precisely re-using/simulating as in the actual Secret Storage
+    The data structure is precisely reusing/simulating as in the actual Secret Storage
     """
+
+    KNOWN_MODEL_ERRORS = [MODEL_ERRORS["no_label_and_uri"], MODEL_ERRORS["owner_no_refresh"]]
 
     def __init__(
         self,
@@ -570,6 +630,95 @@ class CachedSecret:
         self.component = component
         self.legacy_labels = legacy_labels
         self.current_label = None
+
+    @property
+    def meta(self) -> Optional[Secret]:
+        """Getting cached secret meta-information."""
+        if not self._secret_meta:
+            if not (self._secret_uri or self.label):
+                return
+
+            try:
+                self._secret_meta = self._model.get_secret(label=self.label)
+            except SecretNotFoundError:
+                # Falling back to seeking for potential legacy labels
+                self._legacy_compat_find_secret_by_old_label()
+
+            # If still not found, to be checked by URI, to be labelled with the proposed label
+            if not self._secret_meta and self._secret_uri:
+                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
+        return self._secret_meta
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on rolling upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see the spec.)
+    # All data involves:
+    #   - databag contents
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Compatibility
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_find_secret_by_old_label(self) -> None:
+        """Compatibility function, allowing to find a secret by a legacy label.
+
+        This functionality is typically needed when secret labels changed over an upgrade.
+        Until the first write operation, we need to maintain data as it was, including keeping
+        the old secret label. In order to keep track of the old label currently used to access
+        the secret, and additional 'current_label' field is being defined.
+        """
+        for label in self.legacy_labels:
+            try:
+                self._secret_meta = self._model.get_secret(label=label)
+            except SecretNotFoundError:
+                pass
+            else:
+                if label != self.label:
+                    self.current_label = label
+                return
+
+    # Migrations
+
+    @legacy_apply_from_version(34)
+    def _legacy_migration_to_new_label_if_needed(self) -> None:
+        """Helper function to re-create the secret with a different label.
+
+        Juju does not provide a way to change secret labels.
+        Thus whenever moving from secrets version that involves secret label changes,
+        we "re-create" the existing secret, and attach the new label to the new
+        secret, to be used from then on.
+
+        Note: we replace the old secret with a new one "in place", as we can't
+        easily switch the containing SecretCache structure to point to a new secret.
+        Instead we are changing the 'self' (CachedSecret) object to point to the
+        new instance.
+        """
+        if not self.current_label or not (self.meta and self._secret_meta):
+            return
+
+        # Create a new secret with the new label
+        content = self._secret_meta.get_content()
+        self._secret_uri = None
+
+        # It will be nice to have the possibility to check if we are the owners of the secret...
+        try:
+            self._secret_meta = self.add_secret(content, label=self.label)
+        except ModelError as err:
+            if MODEL_ERRORS["not_leader"] not in str(err):
+                raise
+        self.current_label = None
+
+    ##########################################################################
+    # Public functions
+    ##########################################################################
 
     def add_secret(
         self,
@@ -593,28 +742,6 @@ class CachedSecret:
         self._secret_meta = secret
         return self._secret_meta
 
-    @property
-    def meta(self) -> Optional[Secret]:
-        """Getting cached secret meta-information."""
-        if not self._secret_meta:
-            if not (self._secret_uri or self.label):
-                return
-
-            for label in [self.label] + self.legacy_labels:
-                try:
-                    self._secret_meta = self._model.get_secret(label=label)
-                except SecretNotFoundError:
-                    pass
-                else:
-                    if label != self.label:
-                        self.current_label = label
-                    break
-
-            # If still not found, to be checked by URI, to be labelled with the proposed label
-            if not self._secret_meta and self._secret_uri:
-                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
-        return self._secret_meta
-
     def get_content(self) -> Dict[str, str]:
         """Getting cached secret content."""
         if not self._secret_content:
@@ -624,42 +751,25 @@ class CachedSecret:
                 except (ValueError, ModelError) as err:
                     # https://bugs.launchpad.net/juju/+bug/2042596
                     # Only triggered when 'refresh' is set
-                    known_model_errors = [
-                        "ERROR either URI or label should be used for getting an owned secret but not both",
-                        "ERROR secret owner cannot use --refresh",
-                    ]
                     if isinstance(err, ModelError) and not any(
-                        msg in str(err) for msg in known_model_errors
+                        msg in str(err) for msg in self.KNOWN_MODEL_ERRORS
                     ):
                         raise
                     # Due to: ValueError: Secret owner cannot use refresh=True
                     self._secret_content = self.meta.get_content()
         return self._secret_content
 
-    def _move_to_new_label_if_needed(self):
-        """Helper function to re-create the secret with a different label."""
-        if not self.current_label or not (self.meta and self._secret_meta):
-            return
-
-        # Create a new secret with the new label
-        old_meta = self._secret_meta
-        content = self._secret_meta.get_content()
-
-        # I wish we could just check if we are the owners of the secret...
-        try:
-            self._secret_meta = self.add_secret(content, label=self.label)
-        except ModelError as err:
-            if "this unit is not the leader" not in str(err):
-                raise
-        old_meta.remove_all_revisions()
-
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
         if not self.meta:
             return
 
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
+            return
+
         if content:
-            self._move_to_new_label_if_needed()
+            self._legacy_migration_to_new_label_if_needed()
             self.meta.set_content(content)
             self._secret_content = content
         else:
@@ -922,6 +1032,23 @@ class Data(ABC):
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         raise NotImplementedError
 
+    # Optional overrides
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """This function should provide a list of compatibility functions to be applied when fetching (legacy) data."""
+        pass
+
+    def _legacy_apply_on_update(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when writing data.
+
+        Since data may be at a legacy version, migration may be mandatory.
+        """
+        pass
+
+    def _legacy_apply_on_delete(self, fields: List[str]) -> None:
+        """This function should provide a list of compatibility functions to be applied when deleting (legacy) data."""
+        pass
+
     # Internal helper methods
 
     @staticmethod
@@ -1174,6 +1301,16 @@ class Data(ABC):
 
         return relation
 
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Get the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[self.component].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, secret_uri: str) -> None:
+        """Set the secret URI for the corresponding group."""
+        secret_field = self._generate_secret_field_name(group)
+        relation.data[self.component][secret_field] = secret_uri
+
     def fetch_relation_data(
         self,
         relation_ids: Optional[List[int]] = None,
@@ -1190,6 +1327,8 @@ class Data(ABC):
             a dict of the values stored in the relation data bag
                 for all relation instances (indexed by the relation ID).
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
@@ -1228,6 +1367,8 @@ class Data(ABC):
         NOTE: Since only the leader can read the relation's 'this_app'-side
         Application databag, the functionality is limited to leaders
         """
+        self._legacy_apply_on_fetch()
+
         if not relation_name:
             relation_name = self.relation_name
 
@@ -1259,6 +1400,8 @@ class Data(ABC):
     @leader_only
     def update_relation_data(self, relation_id: int, data: dict) -> None:
         """Update the data within the relation."""
+        self._legacy_apply_on_update(list(data.keys()))
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._update_relation_data(relation, data)
@@ -1266,6 +1409,8 @@ class Data(ABC):
     @leader_only
     def delete_relation_data(self, relation_id: int, fields: List[str]) -> None:
         """Remove field from the relation."""
+        self._legacy_apply_on_delete(fields)
+
         relation_name = self.relation_name
         relation = self.get_relation(relation_name, relation_id)
         return self._delete_relation_data(relation, fields)
@@ -1312,6 +1457,8 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
+    RESOURCE_FIELD = "database"
+
     def __init__(
         self,
         model: Model,
@@ -1332,8 +1479,7 @@ class ProviderData(Data):
         uri_to_databag=True,
     ) -> bool:
         """Add a new Juju Secret that will be registered in the relation databag."""
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if uri_to_databag and relation.data[self.component].get(secret_field):
+        if uri_to_databag and self.get_secret_uri(relation, group_mapping):
             logging.error("Secret for relation %s already exists, not adding again", relation.id)
             return False
 
@@ -1344,7 +1490,7 @@ class ProviderData(Data):
 
         # According to lint we may not have a Secret ID
         if uri_to_databag and secret.meta and secret.meta.id:
-            relation.data[self.component][secret_field] = secret.meta.id
+            self.set_secret_uri(relation, group_mapping, secret.meta.id)
 
         # Return the content that was added
         return True
@@ -1445,8 +1591,7 @@ class ProviderData(Data):
         if not relation:
             return
 
-        secret_field = self._generate_secret_field_name(group_mapping)
-        if secret_uri := relation.data[self.local_app].get(secret_field):
+        if secret_uri := self.get_secret_uri(relation, group_mapping):
             return self.secrets.get(label, secret_uri)
 
     def _fetch_specific_relation_data(
@@ -1479,6 +1624,15 @@ class ProviderData(Data):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -1586,7 +1740,7 @@ class RequirerData(Data):
         """
         label = self._generate_secret_label(relation_name, relation_id, group)
 
-        # Fetchin the Secret's meta information ensuring that it's locally getting registered with
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
         CachedSecret(self._model, self.component, label, secret_id).meta
 
     def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
@@ -1599,11 +1753,10 @@ class RequirerData(Data):
 
         for group in SECRET_GROUPS.groups():
             secret_field = self._generate_secret_field_name(group)
-            if secret_field in params_name_list:
-                if secret_uri := relation.data[relation.app].get(secret_field):
-                    self._register_secret_to_relation(
-                        relation.name, relation.id, secret_uri, group
-                    )
+            if secret_field in params_name_list and (
+                secret_uri := self.get_secret_uri(relation, group)
+            ):
+                self._register_secret_to_relation(relation.name, relation.id, secret_uri, group)
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
@@ -1613,6 +1766,17 @@ class RequirerData(Data):
             relation.id, {}
         )
         return bool(data.get("username")) and bool(data.get("password"))
+
+    # Public functions
+
+    def get_secret_uri(self, relation: Relation, group: SecretGroup) -> Optional[str]:
+        """Getting relation secret URI for the corresponding Secret Group."""
+        secret_field = self._generate_secret_field_name(group)
+        return relation.data[relation.app].get(secret_field)
+
+    def set_secret_uri(self, relation: Relation, group: SecretGroup, uri: str) -> None:
+        """Setting relation secret URI is not possible for a Requirer."""
+        raise NotImplementedError("Requirer can not change the relation secret URI.")
 
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
@@ -1764,7 +1928,6 @@ class DataPeerData(RequirerData, ProviderData):
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
     ):
-        """Manager of base client relations."""
         RequirerData.__init__(
             self,
             model,
@@ -1775,6 +1938,11 @@ class DataPeerData(RequirerData, ProviderData):
         self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
         self.deleted_label = deleted_label
         self._secret_label_map = {}
+
+        # Legacy information holders
+        self._legacy_labels = []
+        self._legacy_secret_uri = None
+
         # Secrets that are being dynamically added within the scope of this event handler run
         self._new_secrets = []
         self._additional_secret_group_mapping = additional_secret_group_mapping
@@ -1849,10 +2017,12 @@ class DataPeerData(RequirerData, ProviderData):
             value: The string value of the secret
             group_mapping: The name of the "secret group", in case the field is to be added to an existing secret
         """
+        self._legacy_apply_on_update([field])
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if self.secrets_enabled and full_field not in self.current_secret_fields:
             self._new_secrets.append(full_field)
-        if self._no_group_with_databag(field, full_field):
+        if self.valid_field_pattern(field, full_field):
             self.update_relation_data(relation_id, {full_field: value})
 
     # Unlike for set_secret(), there's no harm using this operation with static secrets
@@ -1865,6 +2035,8 @@ class DataPeerData(RequirerData, ProviderData):
         group_mapping: Optional[SecretGroup] = None,
     ) -> Optional[str]:
         """Public interface method to fetch secrets only."""
+        self._legacy_apply_on_fetch()
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if (
             self.secrets_enabled
@@ -1872,7 +2044,7 @@ class DataPeerData(RequirerData, ProviderData):
             and field not in self.current_secret_fields
         ):
             return
-        if self._no_group_with_databag(field, full_field):
+        if self.valid_field_pattern(field, full_field):
             return self.fetch_my_relation_field(relation_id, full_field)
 
     @dynamic_secrets_only
@@ -1883,14 +2055,19 @@ class DataPeerData(RequirerData, ProviderData):
         group_mapping: Optional[SecretGroup] = None,
     ) -> Optional[str]:
         """Public interface method to delete secrets only."""
+        self._legacy_apply_on_delete([field])
+
         full_field = self._field_to_internal_name(field, group_mapping)
         if self.secrets_enabled and full_field not in self.current_secret_fields:
             logger.warning(f"Secret {field} from group {group_mapping} was not found")
             return
-        if self._no_group_with_databag(field, full_field):
+
+        if self.valid_field_pattern(field, full_field):
             self.delete_relation_data(relation_id, [full_field])
 
+    ##########################################################################
     # Helpers
+    ##########################################################################
 
     @staticmethod
     def _field_to_internal_name(field: str, group: Optional[SecretGroup]) -> str:
@@ -1932,10 +2109,69 @@ class DataPeerData(RequirerData, ProviderData):
             if k in self.secret_fields
         }
 
-    # Backwards compatibility
+    def valid_field_pattern(self, field: str, full_field: str) -> bool:
+        """Check that no secret group is attempted to be used together without secrets being enabled.
 
-    def _check_deleted_label(self, relation, fields) -> None:
-        """Helper function for legacy behavior."""
+        Secrets groups are impossible to use with versions that are not yet supporting secrets.
+        """
+        if not self.secrets_enabled and full_field != field:
+            logger.error(
+                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
+            )
+            return False
+        return True
+
+    ##########################################################################
+    # Backwards compatibility / Upgrades
+    ##########################################################################
+    # These functions are used to keep backwards compatibility on upgrades
+    # Policy:
+    # All data is kept intact until the first write operation. (This allows a minimal
+    # grace period during which rollbacks are fully safe. For more info see spec.)
+    # All data involves:
+    #   - databag
+    #   - secrets content
+    #   - secret labels (!!!)
+    # Legacy functions must return None, and leave an equally consistent state whether
+    # they are executed or skipped (as a high enough versioned execution environment may
+    # not require so)
+
+    # Full legacy stack for each operation
+
+    def _legacy_apply_on_fetch(self) -> None:
+        """All legacy functions to be applied on fetch."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+
+    def _legacy_apply_on_update(self, fields) -> None:
+        """All legacy functions to be applied on update."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_migration_remove_secret_from_databag(relation, fields)
+        self._legacy_migration_remove_secret_field_name_from_databag(relation)
+
+    def _legacy_apply_on_delete(self, fields) -> None:
+        """All legacy functions to be applied on delete."""
+        relation = self._model.relations[self.relation_name][0]
+        self._legacy_compat_generate_prev_labels()
+        self._legacy_compat_secret_uri_from_databag(relation)
+        self._legacy_compat_check_deleted_label(relation, fields)
+
+    # Compatibility
+
+    @legacy_apply_from_version(18)
+    def _legacy_compat_check_deleted_label(self, relation, fields) -> None:
+        """Helper function for legacy behavior.
+
+        As long as https://bugs.launchpad.net/juju/+bug/2028094 wasn't fixed,
+        we did not delete fields but rather kept them in the secret with a string value
+        expressing invalidity. This function is maintainnig that behavior when needed.
+        """
+        if not self.deleted_label:
+            return
+
         current_data = self.fetch_my_relation_data([relation.id], fields)
         if current_data is not None:
             # Check if the secret we wanna delete actually exists
@@ -1948,7 +2184,43 @@ class DataPeerData(RequirerData, ProviderData):
                     ", ".join(non_existent),
                 )
 
-    def _remove_secret_from_databag(self, relation, fields: List[str]) -> None:
+    @legacy_apply_from_version(18)
+    def _legacy_compat_secret_uri_from_databag(self, relation) -> None:
+        """Fetching the secret URI from the databag, in case stored there."""
+        self._legacy_secret_uri = relation.data[self.component].get(
+            self._generate_secret_field_name(), None
+        )
+
+    @legacy_apply_from_version(34)
+    def _legacy_compat_generate_prev_labels(self) -> None:
+        """Generator for legacy secret label names, for backwards compatibility.
+
+        Secret label is part of the data that MUST be maintained across rolling upgrades.
+        In case there may be a change on a secret label, the old label must be recognized
+        after upgrades, and left intact until the first write operation -- when we roll over
+        to the new label.
+
+        This function keeps "memory" of previously used secret labels.
+        NOTE: Return value takes decorator into account -- all 'legacy' functions may return `None`
+
+        v0.34 (rev69): Fixing issue https://github.com/canonical/data-platform-libs/issues/155
+                       meant moving from '<app_name>.<scope>' (i.e. 'mysql.app', 'mysql.unit')
+                       to labels '<relation_name>.<app_name>.<scope>' (like 'peer.mysql.app')
+        """
+        if self._legacy_labels:
+            return
+
+        result = []
+        members = [self._model.app.name]
+        if self.scope:
+            members.append(self.scope.value)
+        result.append(f"{'.'.join(members)}")
+        self._legacy_labels = result
+
+    # Migration
+
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_from_databag(self, relation, fields: List[str]) -> None:
         """For Rolling Upgrades -- when moving from databag to secrets usage.
 
         Practically what happens here is to remove stuff from the databag that is
@@ -1962,10 +2234,16 @@ class DataPeerData(RequirerData, ProviderData):
             if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
                 self._delete_relation_data_without_secrets(self.component, relation, [field])
 
-    def _remove_secret_field_name_from_databag(self, relation) -> None:
+    @legacy_apply_from_version(18)
+    def _legacy_migration_remove_secret_field_name_from_databag(self, relation) -> None:
         """Making sure that the old databag URI is gone.
 
         This action should not be executed more than once.
+
+        There was a phase (before moving secrets usage to libs) when charms saved the peer
+        secret URI to the databag, and used this URI from then on to retrieve their secret.
+        When upgrading to charm versions using this library, we need to add a label to the
+        secret and access it via label from than on, and remove the old traces from the databag.
         """
         # Nothing to do if 'internal-secret' is not in the databag
         if not (relation.data[self.component].get(self._generate_secret_field_name())):
@@ -1981,25 +2259,9 @@ class DataPeerData(RequirerData, ProviderData):
             # Databag reference to the secret URI can be removed, now that it's labelled
             relation.data[self.component].pop(self._generate_secret_field_name(), None)
 
-    def _previous_labels(self) -> List[str]:
-        """Generator for legacy secret label names, for backwards compatibility."""
-        result = []
-        members = [self._model.app.name]
-        if self.scope:
-            members.append(self.scope.value)
-        result.append(f"{'.'.join(members)}")
-        return result
-
-    def _no_group_with_databag(self, field: str, full_field: str) -> bool:
-        """Check that no secret group is attempted to be used together with databag."""
-        if not self.secrets_enabled and full_field != field:
-            logger.error(
-                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
-            )
-            return False
-        return True
-
+    ##########################################################################
     # Event handlers
+    ##########################################################################
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
@@ -2009,7 +2271,9 @@ class DataPeerData(RequirerData, ProviderData):
         """Event emitted when the secret has changed."""
         pass
 
+    ##########################################################################
     # Overrides of Relation Data handling functions
+    ##########################################################################
 
     def _generate_secret_label(
         self, relation_name: str, relation_id: int, group_mapping: SecretGroup
@@ -2046,13 +2310,14 @@ class DataPeerData(RequirerData, ProviderData):
             return
 
         label = self._generate_secret_label(relation_name, relation_id, group_mapping)
-        secret_uri = relation.data[self.component].get(self._generate_secret_field_name(), None)
 
         # URI or legacy label is only to applied when moving single legacy secret to a (new) label
         if group_mapping == SECRET_GROUPS.EXTRA:
             # Fetching the secret with fallback to URI (in case label is not yet known)
             # Label would we "stuck" on the secret in case it is found
-            return self.secrets.get(label, secret_uri, legacy_labels=self._previous_labels())
+            return self.secrets.get(
+                label, self._legacy_secret_uri, legacy_labels=self._legacy_labels
+            )
         return self.secrets.get(label)
 
     def _get_group_secret_contents(
@@ -2082,7 +2347,6 @@ class DataPeerData(RequirerData, ProviderData):
     @either_static_or_dynamic_secrets
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
-        self._remove_secret_from_databag(relation, list(data.keys()))
         _, normal_fields = self._process_secret_fields(
             relation,
             self.secret_fields,
@@ -2091,7 +2355,6 @@ class DataPeerData(RequirerData, ProviderData):
             data=data,
             uri_to_databag=False,
         )
-        self._remove_secret_field_name_from_databag(relation)
 
         normal_content = {k: v for k, v in data.items() if k in normal_fields}
         self._update_relation_data_without_secrets(self.component, relation, normal_content)
@@ -2100,9 +2363,6 @@ class DataPeerData(RequirerData, ProviderData):
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         if self.secret_fields and self.deleted_label:
-            # Legacy, backwards compatibility
-            self._check_deleted_label(relation, fields)
-
             _, normal_fields = self._process_secret_fields(
                 relation,
                 self.secret_fields,
@@ -2137,7 +2397,9 @@ class DataPeerData(RequirerData, ProviderData):
             "fetch_my_relation_data() and fetch_my_relation_field()"
         )
 
+    ##########################################################################
     # Public functions -- inherited
+    ##########################################################################
 
     fetch_my_relation_data = Data.fetch_my_relation_data
     fetch_my_relation_field = Data.fetch_my_relation_field
@@ -2309,7 +2571,7 @@ class RelationEventWithSecret(RelationEvent):
         return self._cached_secrets
 
     def _get_secret(self, group) -> Optional[Dict[str, str]]:
-        """Retrieveing secrets."""
+        """Retrieving secrets."""
         if not self.app:
             return
         if not self._secrets.get(group):
@@ -2602,6 +2864,14 @@ class DatabaseProviderData(ProviderData):
         """
         self.update_relation_data(relation_id, {"version": version})
 
+    def set_subordinated(self, relation_id: int) -> None:
+        """Raises the subordinated flag in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        self.update_relation_data(relation_id, {"subordinated": "true"})
+
 
 class DatabaseProviderEventHandlers(EventHandlers):
     """Provider-side of the database relation handlers."""
@@ -2838,6 +3108,20 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
+        is_subordinate = False
+        remote_unit_data = None
+        for key in event.relation.data.keys():
+            if isinstance(key, Unit) and not key.name.startswith(self.charm.app.name):
+                remote_unit_data = event.relation.data[key]
+            elif isinstance(key, Application) and key.name != self.charm.app.name:
+                is_subordinate = event.relation.data[key].get("subordinated") == "true"
+
+        if is_subordinate and not remote_unit_data:
+            return
+
+        if is_subordinate and remote_unit_data.get("state") != "ready":
+            return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
@@ -3018,6 +3302,8 @@ class KafkaRequiresEvents(CharmEvents):
 
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
+
+    RESOURCE_FIELD = "topic"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
@@ -3267,6 +3553,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
+
+    RESOURCE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/tests/integration/app-charm/src/charm.py
+++ b/tests/integration/app-charm/src/charm.py
@@ -10,11 +10,11 @@ of the libraries in this repository.
 
 import logging
 
-from ops.charm import CharmBase
+from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
 
-from relations.spark_sa import IntegrationHubRequirer, ServiceAccountGrantedEvent
+from relations.spark_sa import ServiceAccountGrantedEvent, SparkServiceAccountRequirer
 
 logger = logging.getLogger(__name__)
 
@@ -35,25 +35,44 @@ class ApplicationCharm(CharmBase):
 
         namespace = self.config["namespace"]
 
-        self.sa1 = IntegrationHubRequirer(
-            self, relation_name=REL_NAME_A, service_account="sa1", namespace=namespace
+        self.sa1 = SparkServiceAccountRequirer(
+            self, relation_name=REL_NAME_A, service_account=f"{namespace}:sa1"
         )
-        self.sa2 = IntegrationHubRequirer(
-            self, relation_name=REL_NAME_B, service_account="sa2", namespace=namespace
+        self.sa2 = SparkServiceAccountRequirer(
+            self, relation_name=REL_NAME_B, service_account=f"{namespace}:sa2"
         )
 
         self.framework.observe(self.sa1.on.account_granted, self.on_account_granted_sa_1)
         self.framework.observe(self.sa2.on.account_granted, self.on_account_granted_sa_2)
 
+        self.framework.observe(self.on.get_properties_sa1_action, self._get_properties_sa1_action)
+        self.framework.observe(self.on.get_properties_sa2_action, self._get_properties_sa2_action)
+
     def _on_start(self, _) -> None:
         self.unit.status = ActiveStatus()
 
     def on_account_granted_sa_1(self, event: ServiceAccountGrantedEvent) -> None:
-        logger.info(f"{event.service_account} {event.namespace}")
+        logger.info(f"{event.service_account}")
         return
 
     def on_account_granted_sa_2(self, event: ServiceAccountGrantedEvent) -> None:
-        logger.info(f"{event.service_account} {event.namespace}")
+        logger.info(f"{event.service_account}")
+        return
+
+    def _get_properties_sa1_action(self, event: ActionEvent) -> None:
+        relation = self.model.get_relation(relation_name=REL_NAME_A)
+        if relation is None:
+            return
+        properties = self.sa1.fetch_relation_field(relation.id, "spark-properties")
+        event.set_results({"spark-properties": properties})
+        return
+
+    def _get_properties_sa2_action(self, event: ActionEvent) -> None:
+        relation = self.model.get_relation(relation_name=REL_NAME_B)
+        if relation is None:
+            return
+        properties = self.sa2.fetch_relation_field(relation.id, "spark-properties")
+        event.set_results({"spark-properties": properties})
         return
 
 

--- a/tests/integration/app-charm/src/relations/spark_sa.py
+++ b/tests/integration/app-charm/src/relations/spark_sa.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 r"""A library for creating service accounts that are configured to run Spark jobs."""
+
 import json
 import logging
 from collections import namedtuple
@@ -46,6 +47,7 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+SPARK_PROPERTIES_RELATION_FIELD = "spark-properties"
 
 logger = logging.getLogger(__name__)
 
@@ -106,24 +108,16 @@ class ServiceAccountEvent(RelationEvent):
 
         return self.relation.data[self.relation.app].get("service-account", "")
 
-    @property
-    def namespace(self) -> Optional[str]:
-        """Returns the namespace that was requested."""
-        if not self.relation.app:
-            return None
-
-        return self.relation.data[self.relation.app].get("namespace", "")
-
 
 class ServiceAccountRequestedEvent(ServiceAccountEvent):
-    """Event emitted when a set of service account/namespace is requested for use on this relation."""
+    """Event emitted when a set of service account is requested for use on this relation."""
 
 
 class ServiceAccountReleasedEvent(ServiceAccountEvent):
-    """Event emitted when a set of service account/namespace is released."""
+    """Event emitted when a set of service account is released."""
 
 
-class IntegrationHubProviderEvents(CharmEvents):
+class SparkServiceAccountProviderEvents(CharmEvents):
     """Event descriptor for events raised by ServiceAccountProvider."""
 
     account_requested = EventSource(ServiceAccountRequestedEvent)
@@ -138,18 +132,17 @@ class ServiceAccountGoneEvent(RelationEvent):
     """Event emitted when service account are removed from this relation."""
 
 
-class IntegrationHubRequirerEvents(ObjectEvents):
+class SparkServiceAccountRequirerEvents(ObjectEvents):
     """Event descriptor for events raised by the Requirer."""
 
     account_granted = EventSource(ServiceAccountGrantedEvent)
     account_gone = EventSource(ServiceAccountGoneEvent)
 
 
-# Integration Hub Provider and Requirer
+class SparkServiceAccountProviderData(ProviderData):
+    """Provider-side of the Spark Service Account relation."""
 
-
-class IntegrationHubProviderData(ProviderData):
-    """Provider-side of the Spark Integration Hub relation."""
+    RESOURCE_FIELD = "service-account"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
@@ -163,22 +156,22 @@ class IntegrationHubProviderData(ProviderData):
         """
         self.update_relation_data(relation_id, {"service-account": service_account})
 
-    def set_namespace(self, relation_id: int, namespace: str) -> None:
-        """Set the bootstrap server in the application relation databag.
+    def set_spark_properties(self, relation_id: int, spark_properties: str) -> None:
+        """Set the Spark properties in the application relation databag.
 
         Args:
             relation_id: the identifier for a particular relation.
-            namespace: the namespace name.
+            spark_properties: the dictionary that contains key-value for Spark properties.
         """
-        self.update_relation_data(relation_id, {"namespace": namespace})
+        self.update_relation_data(relation_id, {SPARK_PROPERTIES_RELATION_FIELD: spark_properties})
 
 
-class IntegrationHubProviderEventHandlers(EventHandlers):
-    """Provider-side of the Integration Hub relation."""
+class SparkServiceAccountProviderEventHandlers(EventHandlers):
+    """Provider-side of the Spark Service Account relation."""
 
-    on = IntegrationHubProviderEvents()  # pyright: ignore [reportAssignmentType]
+    on = SparkServiceAccountProviderEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: IntegrationHubProviderData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: SparkServiceAccountProviderData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -195,7 +188,7 @@ class IntegrationHubProviderEventHandlers(EventHandlers):
 
         diff = self._diff(event)
         # emit on account requested if service account name is provided by the requirer application
-        if "service-account" in diff.added and "namespace" in diff.added:
+        if "service-account" in diff.added:
             getattr(self.on, "account_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
@@ -209,29 +202,33 @@ class IntegrationHubProviderEventHandlers(EventHandlers):
         getattr(self.on, "account_released").emit(event.relation, app=event.app, unit=event.unit)
 
 
-class IntegrationHubProvider(IntegrationHubProviderData, IntegrationHubProviderEventHandlers):
-    """Provider-side of the Integration Hub relation."""
+class SparkServiceAccountProvider(
+    SparkServiceAccountProviderData, SparkServiceAccountProviderEventHandlers
+):
+    """Provider-side of the Spark Service Account relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        IntegrationHubProviderData.__init__(self, charm.model, relation_name)
-        IntegrationHubProviderEventHandlers.__init__(self, charm, self)
+        SparkServiceAccountProviderData.__init__(self, charm.model, relation_name)
+        SparkServiceAccountProviderEventHandlers.__init__(self, charm, self)
 
 
-class IntegrationHubRequirerData(RequirerData):
-    """Requirer-side of the Integration Hub relation."""
+class SparkServiceAccountRequirerData(RequirerData):
+    """Requirer-side of the Spark Service Account relation."""
 
     def __init__(
         self,
         model: Model,
         relation_name: str,
         service_account: str,
-        namespace: str,
         additional_secret_fields: Optional[List[str]] = [],
     ):
-        """Manager of Integration Hub relations."""
+        """Manager of Spark Service Account relations."""
+        if not additional_secret_fields:
+            additional_secret_fields = []
+        if SPARK_PROPERTIES_RELATION_FIELD not in additional_secret_fields:
+            additional_secret_fields.append(SPARK_PROPERTIES_RELATION_FIELD)
         super().__init__(model, relation_name, additional_secret_fields=additional_secret_fields)
         self.service_account = service_account
-        self.namespace = namespace
 
     @property
     def service_account(self):
@@ -242,22 +239,13 @@ class IntegrationHubRequirerData(RequirerData):
     def service_account(self, value):
         self._service_account = value
 
-    @property
-    def namespace(self):
-        """Namespace used for running Spark jobs."""
-        return self._namespace
 
-    @namespace.setter
-    def namespace(self, value):
-        self._namespace = value
+class SparkServiceAccountRequirerEventHandlers(RequirerEventHandlers):
+    """Requirer-side of the Spark Service Account relation."""
 
+    on = SparkServiceAccountRequirerEvents()  # pyright: ignore [reportAssignmentType]
 
-class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
-    """Requirer-side of the Integration Hub relation."""
-
-    on = IntegrationHubRequirerEvents()  # pyright: ignore [reportAssignmentType]
-
-    def __init__(self, charm: CharmBase, relation_data: IntegrationHubRequirerData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: SparkServiceAccountRequirerData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -267,16 +255,15 @@ class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
         )
 
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
-        """Event emitted when the Integration Hub relation is created."""
+        """Event emitted when the Spark Service Account relation is created."""
         super()._on_relation_created_event(event)
 
         if not self.relation_data.local_unit.is_leader():
             return
 
-        # Sets service_account, namespace in the relation
+        # Sets service_account in the relation
         relation_data = {
-            f: getattr(self.relation_data, f.replace("-", "_"), "")
-            for f in ["service-account", "namespace"]
+            f: getattr(self.relation_data, f.replace("-", "_"), "") for f in ["service-account"]
         }
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
@@ -286,12 +273,10 @@ class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
         pass
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the Integration Hub relation has changed."""
-        logger.info("On Integration Hub relation changed")
+        """Event emitted when the Spark Service Account relation has changed."""
+        logger.info("On Spark Service Account relation changed")
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
-
-        # Check if the service-account is created in the desired namespace
 
         # Register all new secrets with their labels
         if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
@@ -300,7 +285,7 @@ class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
         secret_field_user = self.relation_data._generate_secret_field_name(SECRET_GROUPS.USER)
 
         if (
-            "service-account" in diff.added and "namespace" in diff.added
+            "service-account" in diff.added and "spark-properties" in diff.added
         ) or secret_field_user in diff.added:
             getattr(self.on, "account_granted").emit(
                 event.relation, app=event.app, unit=event.unit
@@ -308,27 +293,27 @@ class IntegrationHubRequirerEventHandlers(RequirerEventHandlers):
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Notify the charm about a broken service account relation."""
-        logger.info("On Integration Hub relation gone")
+        logger.info("On Spark Service Account relation gone")
         getattr(self.on, "account_gone").emit(event.relation, app=event.app, unit=event.unit)
 
 
-class IntegrationHubRequirer(IntegrationHubRequirerData, IntegrationHubRequirerEventHandlers):
-    """Provider-side of the Integration Hub relation."""
+class SparkServiceAccountRequirer(
+    SparkServiceAccountRequirerData, SparkServiceAccountRequirerEventHandlers
+):
+    """Requirer side of the Spark Service Account relation."""
 
     def __init__(
         self,
         charm: CharmBase,
         relation_name: str,
         service_account: str,
-        namespace: str,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        IntegrationHubRequirerData.__init__(
+        SparkServiceAccountRequirerData.__init__(
             self,
             charm.model,
             relation_name,
             service_account,
-            namespace,
             additional_secret_fields,
         )
-        IntegrationHubRequirerEventHandlers.__init__(self, charm, self)
+        SparkServiceAccountRequirerEventHandlers.__init__(self, charm, self)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -157,12 +157,12 @@ def setup_s3_bucket_for_sch_server(endpoint_url: str, aws_access_key: str, aws_s
 async def run_action(
     ops_test: OpsTest, action_name: str, params: Dict[str, str], app_name: str, num_unit=0
 ) -> Any:
-    """Use the charm action to start a password rotation."""
+    """Run the given charm action in given charm with given parameters."""
     action = await ops_test.model.units.get(f"{app_name}/{num_unit}").run_action(
         action_name, **params
     )
-    password = await action.wait()
-    return password.results
+    action_result = await action.wait()
+    return action_result.results
 
 
 def flatten(map: MutableMapping, parent: str = "", separator: str = ".") -> dict[str, str]:

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -144,5 +144,5 @@ async def test_integration_hub_relation(ops_test: OpsTest, namespace):
 
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_APP_NAME], timeout=600)
 
-    # The service account named 'sa1' should have been created
+    # The service account named 'sa1' should have been removed
     assert not check_service_account_existance(namespace, "sa1")

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -8,6 +8,8 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
+from .helpers import run_action
+
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -87,9 +89,11 @@ async def test_integration_hub_relation(ops_test: OpsTest, namespace):
 
     logger.info(f"Add namespace: {namespace}")
     configuration_parameters = {"namespace": namespace}
+
     # apply new configuration options
     await ops_test.model.applications[DUMMY_APP_NAME].set_config(configuration_parameters)
 
+    # Add a new relation between dummy application charm and integration hub
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_APP_NAME}:{REL_NAME_A}")
 
     async with ops_test.fast_forward(fast_interval="60s"):
@@ -97,19 +101,48 @@ async def test_integration_hub_relation(ops_test: OpsTest, namespace):
             apps=[APP_NAME, DUMMY_APP_NAME], idle_period=30, status="active", timeout=2000
         )
 
+    # The service account named 'sa1' should have been created
     assert check_service_account_existance(namespace, "sa1")
 
+    # Add a spark property via configuration action of integration hub
+    await run_action(
+        ops_test=ops_test, action_name="add-config", params={"conf": "foo=bar"}, app_name=APP_NAME
+    )
+    async with ops_test.fast_forward(fast_interval="60s"):
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, DUMMY_APP_NAME], idle_period=30, status="active", timeout=2000
+        )
+
+    # The added spark property be reflected on the requirer charm
+    res = await run_action(
+        ops_test=ops_test, action_name="get-properties-sa1", params={}, app_name=DUMMY_APP_NAME
+    )
+    properties = res.get("spark-properties", {})
+    assert "foo" in json.loads(properties)
+
+    # Add a new relation between dummy application charm and integration hub
     await ops_test.model.add_relation(APP_NAME, f"{DUMMY_APP_NAME}:{REL_NAME_B}")
 
     async with ops_test.fast_forward(fast_interval="60s"):
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, DUMMY_APP_NAME], idle_period=30, status="active", timeout=2000
         )
-    assert check_service_account_existance(namespace, "sa1")
 
+    # The service account named 'sa2' should have been created
+    assert check_service_account_existance(namespace, "sa2")
+
+    res = await run_action(
+        ops_test=ops_test, action_name="get-properties-sa2", params={}, app_name=DUMMY_APP_NAME
+    )
+    properties = res.get("spark-properties", {})
+    assert "foo" in json.loads(properties)
+
+    # Remove the relation between dummy application charm and integration hub
     await ops_test.model.applications[APP_NAME].remove_relation(
         f"{APP_NAME}:spark-service-account", f"{DUMMY_APP_NAME}:{REL_NAME_A}"
     )
 
     await ops_test.model.wait_for_idle(apps=[APP_NAME, DUMMY_APP_NAME], timeout=600)
+
+    # The service account named 'sa1' should have been created
     assert not check_service_account_existance(namespace, "sa1")

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 description = Apply coding style standards to code
 commands =
     poetry install --only format
-    poetry run ruff check --fix {[vars]all_path}
+    poetry run ruff check --fix {[vars]all_path} --exclude tests/integration/app-charm/lib
     poetry run black {[vars]all_path}
 
 [testenv:lint]


### PR DESCRIPTION
This PR:
1) specifies the charm lib for `SparkServiceAccountProvider` and `SparkServiceAccountRequirer` classes to be used for creation and use of Spark service accounts.
2) Implements the provider side of the spark service account relation.

The charm lib will later be moved to `data_platform_libs` -- however I wanted to get the review approval for the content of the lib before I migrate it to the data_platform_libs. Once I get an approval for this PR, I will then publish the lib to data_platform_libs and then have it used in this charm.