### PR TITLE
[MISC] Update example docstring in spark_service_account lib

### DIFF
--- a/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -26,7 +26,7 @@ of the application charm code:
 ```python
 import json
 
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirer,
     ServiceAccountGrantedEvent,
     ServiceAccountPropertyChangedEvent,
@@ -122,7 +122,7 @@ Following is an example of using the SparkServiceAccountProvider class in the co
 of the application charm code:
 
 ```python
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountProvider,
     ServiceAccountRequestedEvent,
     ServiceAccountReleasedEvent,

--- a/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -26,7 +26,7 @@ of the application charm code:
 ```python
 import json
 
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirer,
     ServiceAccountGrantedEvent,
     ServiceAccountPropertyChangedEvent,
@@ -122,7 +122,7 @@ Following is an example of using the SparkServiceAccountProvider class in the co
 of the application charm code:
 
 ```python
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountProvider,
     ServiceAccountRequestedEvent,
     ServiceAccountReleasedEvent,


### PR DESCRIPTION
Somehow we missed to update the reference in example docstring from `data_platform_libs` to `spark_service_account`. This PR updates that docstring.