### PR TITLE
[MISC] Upgrade spark_service_account libpatch to 2

### DIFF
--- a/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -26,7 +26,7 @@ of the application charm code:
 ```python
 import json
 
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirer,
     ServiceAccountGrantedEvent,
     ServiceAccountPropertyChangedEvent,
@@ -122,7 +122,7 @@ Following is an example of using the SparkServiceAccountProvider class in the co
 of the application charm code:
 
 ```python
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountProvider,
     ServiceAccountRequestedEvent,
     ServiceAccountReleasedEvent,

--- a/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -201,7 +201,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -26,7 +26,7 @@ of the application charm code:
 ```python
 import json
 
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirer,
     ServiceAccountGrantedEvent,
     ServiceAccountPropertyChangedEvent,
@@ -122,7 +122,7 @@ Following is an example of using the SparkServiceAccountProvider class in the co
 of the application charm code:
 
 ```python
-from charms.data_platform_libs.v0.spark_service_account import (
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountProvider,
     ServiceAccountRequestedEvent,
     ServiceAccountReleasedEvent,

--- a/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
+++ b/tests/integration/app-charm/lib/charms/spark_integration_hub_k8s/v0/spark_service_account.py
@@ -201,7 +201,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["ops>=2.0.0"]
 


### PR DESCRIPTION
The earlier PR when merged did not release the changes to charm libs because the LIBPATCH was the same as existing one in CharmHub. This PR increments the LIBPATCH so that the changes get published to charmhub.