### PR TITLE
[DPE-8693] Add juju agent constraint in metadata.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.6/stable
+          bootstrap-options: "--agent-version 3.6.9"
           provider: microk8s
           channel: 1.32-strict/stable
           microk8s-group: snap_microk8s

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,6 +22,7 @@ maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 assumes:
   - k8s-api
+  - juju < 3.6.10
 
 containers:
   integration-hub:


### PR DESCRIPTION
This PR adds a constraint on the juju agent so that we circumvent the issue we have with juju 3.9.11.

I split this in two commits, we can see in the job logs that the first commit did fail the test with the appropriate error message: https://github.com/canonical/spark-integration-hub-k8s-operator/actions/runs/18745824556/job/53473122589?pr=114#step:6:206