### PR TITLE
[PRA-30] Add monitored-service-accounts configuration option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,12 @@ options:
       spark.kubernetes.executor.podTemplateFile=<executor-pod-template>
 
     default: ""
+
+  monitored-service-accounts:
+    type: string
+    description: |
+      Comma-separated patterns for namespaces and service accounts to monitor and update in
+      addition to the ones managed by the charm's relations.
+      Ex.: "namespace1:sa1,namespace2:*".
+
+    default: ""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ resources:
   integration-hub-image:
     type: oci-image
     description: OCI image for the Spark Integration Hub Charm
-    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:498f035278d7973990990ec9541f5736ddf460d93d5dc34fb4344bb9f6c68fd9  # 3-22.04 2025-08-20
+    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:dbcd4bce247df35483bb94606fa11d3316d9d529e1476efa95ef333b78c9f414 # 3-22.04 2025-11-17
 
 requires:
   s3-credentials:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -5,8 +5,10 @@
 """Structured configuration for the Integration Hub charm."""
 
 import logging
+import re
 
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
+from pydantic import Field, validator
 
 logger = logging.getLogger(__name__)
 
@@ -17,3 +19,24 @@ class CharmConfig(BaseConfigModel):
     enable_dynamic_allocation: bool
     driver_pod_template: str
     executor_pod_template: str
+    monitored_service_accounts: list[str] = Field(default="")
+
+    @validator("monitored_service_accounts", pre=True)
+    @classmethod
+    def monitored_service_accounts_validator(cls, value: str) -> list[str]:
+        """Check validity of `monitored-service-accounts` field."""
+        if not value:
+            return []
+        validated = []
+        for sa in value.split(","):
+            if sa.count(":") == 1:
+                key, val = sa.split(":", 1)
+                # pattern = "^[a-z](?:[a-z0-9\\-]{0,61}[a-z0-9])?$"
+                pattern = r"[a-z0-9A-Z\*](?:[a-z0-9\-\*]{0,61}[a-z0-9\*])?$"
+                if not (re.match(pattern, key) and re.match(pattern, val)):
+                    raise ValueError(f"Malformed service accounts: {key}:{val}")
+                validated.append(sa)
+
+            else:
+                raise ValueError("Malformed monitored-service-accounts options.")
+        return validated

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -31,7 +31,6 @@ class CharmConfig(BaseConfigModel):
         for sa in value.split(","):
             if sa.count(":") == 1:
                 key, val = sa.split(":", 1)
-                # pattern = "^[a-z](?:[a-z0-9\\-]{0,61}[a-z0-9])?$"
                 pattern = r"[a-z0-9A-Z\*](?:[a-z0-9\-\*]{0,61}[a-z0-9\*])?$"
                 if not (re.match(pattern, key) and re.match(pattern, val)):
                     raise ValueError(f"Malformed service accounts: {key}:{val}")

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -23,6 +23,11 @@ class IntegrationHubPaths:
         """Return the path of the spark-properties file."""
         return self.conf_path / "spark-properties.conf"
 
+    @property
+    def allowlist(self) -> Path:
+        """Return the path of the allowlist file."""
+        return self.conf_path / "allowlist"
+
 
 class IntegrationHubWorkloadBase(AbstractWorkload):
     """Base interface for common workload operations."""

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -242,10 +242,27 @@ class IntegrationHubManager(WithLogging):
 
         if self._compare_and_update_file(
             config.contents, str(self.workload.paths.spark_properties)
+        ) or self._compare_and_update_file(
+            "\n".join(
+                sorted(
+                    [
+                        *self.config.monitored_service_accounts,
+                        *[
+                            sa.service_account
+                            for sa in self.context.service_accounts
+                            if sa.service_account
+                        ],
+                    ]
+                )
+            ),
+            str(self.workload.paths.allowlist),
         ):
             self.logger.info("Updating integration hub config...")
             self.workload.set_environment(
-                {"SPARK_PROPERTIES_FILE": str(self.workload.paths.spark_properties)}
+                {
+                    "SPARK_PROPERTIES_FILE": str(self.workload.paths.spark_properties),
+                    "SA_ALLOWLIST": str(self.workload.paths.allowlist),
+                },
             )
             self.workload.restart()
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -63,6 +63,20 @@ def get_secret_data(namespace: str, secret_name: str):
         return e.stdout.decode(), e.stderr.decode(), e.returncode
 
 
+def does_secret_exist(namespace: str, secret_name: str) -> bool:
+    """Check secret existence for a given namespace and secret name."""
+    command = ["kubectl", "get", "secret", "-n", namespace, "--output", "json"]
+    output = subprocess.run(command, check=True, capture_output=True)
+    result = output.stdout.decode()
+    secrets = json.loads(result)
+    for secret in secrets["items"]:
+        name = secret["metadata"]["name"]
+        logger.info(f"\t secretName: {name}")
+        if name == secret_name:
+            return True
+    return False
+
+
 def get_address(juju: jubilant.Juju, unit_name: str) -> str:
     status = juju.status()
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -81,6 +81,8 @@ def test_relation_with_s3(
     service_account_name = service_account[0]
     namespace = service_account[1]
     logger.info(f"Service account: {service_account_name}, namespace: {namespace}")
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(jubilant.all_active, delay=5)
 
     # Verify that secret data is empty before S3 relation is added.
     secret_data = get_secret_data(
@@ -111,9 +113,8 @@ def test_new_service_account_with_s3(
     namespace = service_account[1]
     logger.info(f"Service account: {service_account_name}, namespace: {namespace}")
 
-    # Wait for some time for the secrets to be reflected
-    logger.info("Waiting for 10 seconds...")
-    time.sleep(10)
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(jubilant.all_active, delay=5)
 
     # check secret
     secret_data = get_secret_data(
@@ -173,6 +174,8 @@ def test_relation_with_azure_storage(
     namespace = service_account[1]
     logger.info(f"Service account: {service_account_name}, namespace: {namespace}")
 
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(jubilant.all_active, delay=5)
     # Verify that secret data is empty before S3 relation is added.
     secret_data = get_secret_data(
         namespace=namespace, secret_name=f"{SECRET_NAME_PREFIX}{service_account_name}"
@@ -208,9 +211,8 @@ def test_new_service_account_with_azure_storage(
     namespace = service_account[1]
     logger.info(f"Service account: {service_account_name}, namespace: {namespace}")
 
-    # Wait for some time for the secrets to be reflected
-    logger.info("Waiting for 10 seconds...")
-    time.sleep(10)
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(jubilant.all_active, delay=5)
 
     # check secret
     secret_data = get_secret_data(
@@ -258,9 +260,8 @@ def test_remove_application(
     namespace = service_account[1]
     logger.info(f"Service account: {service_account_name}, namespace: {namespace}")
 
-    # Wait for some time for the changes in secrets to be reflected
-    logger.info("Waiting for 10 seconds...")
-    time.sleep(10)
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(jubilant.all_active, delay=5)
 
     secret_data = get_secret_data(
         namespace=namespace, secret_name=f"{SECRET_NAME_PREFIX}{service_account_name}"
@@ -274,7 +275,7 @@ def test_remove_application(
 
     # Removing Spark Integration Hub application
     juju.remove_application(APP_NAME)
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, delay=5)
 
     secret_data = get_secret_data(
         namespace=namespace, secret_name=f"{SECRET_NAME_PREFIX}{service_account_name}"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import jubilant
 import yaml
 
-from .helpers import get_secret_data
+from .helpers import does_secret_exist, get_secret_data
 from .types import AzureInfo, IntegrationTestsCharms
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,23 @@ def test_deploy_azure_storage_integrator(
     )
     # juju.wait(lambda status: jubilant.all_active(status, charm_versions.azure_storage.application_name))
     juju.wait(jubilant.all_active)
+
+
+def test_external_service_account_not_monitored(
+    juju: jubilant.Juju, service_account: tuple[str, str]
+) -> None:
+    """Check that service accounts are not monitored by default.
+
+    This test makes sure that we only inject spark properties into a secret *after* we configure the
+    integration hub to monitor a specific service account.
+    """
+    name, namespace = service_account
+    juju.wait(jubilant.all_active, delay=5)
+    assert not does_secret_exist(namespace=namespace, secret_name=f"{SECRET_NAME_PREFIX}{name}")
+
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{name}"})
+    juju.wait(jubilant.all_active, delay=5)
+    assert does_secret_exist(namespace=namespace, secret_name=f"{SECRET_NAME_PREFIX}{name}")
 
 
 def test_relation_with_s3(

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -84,6 +84,12 @@ def test_relation_with_pushgateway(
     Assert on the unit status and on the presence/absence of the metrics.
     """
     service_account_name, namespace = service_account
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        delay=5,
+    )
+
     setup_spark_output = subprocess.check_output(
         f"./tests/integration/setup/setup_spark.sh {service_account_name} {namespace}",
         shell=True,
@@ -171,6 +177,13 @@ def test_relation_with_logging(
     juju: jubilant.Juju, service_account: tuple[str, str], charm_versions: IntegrationTestsCharms
 ) -> None:
     service_account_name, namespace = service_account
+
+    juju.config(APP_NAME, {"monitored-service-accounts": f"{namespace}:{service_account_name}"})
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        delay=5,
+    )
+
     setup_spark_output = subprocess.check_output(
         f"./tests/integration/setup/setup_spark.sh {service_account_name} {namespace}",
         shell=True,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from core.config import CharmConfig
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+
+
+def check_valid_values(field: str, value: Any) -> None:
+    """Check the correctness of the passed values for a field."""
+    flat_config_options = {
+        option_name.replace("-", "_"): mapping.get("default")
+        for option_name, mapping in CONFIG["options"].items()
+    }
+    CharmConfig(**{**flat_config_options, **{field: value}})
+
+
+def check_invalid_values(field: str, value: Any) -> None:
+    """Check the incorrectness of the passed values for a field."""
+    flat_config_options = {
+        option_name.replace("-", "_"): mapping.get("default")
+        for option_name, mapping in CONFIG["options"].items()
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        CharmConfig(**{**flat_config_options, **{field: value}})
+    assert field in excinfo.value.errors()[0]["loc"]
+
+
+@pytest.mark.parametrize(
+    "value", ["", "foo:bar", "foo:bar,sa-1:sa-2", "foo:*,*:sa2", "foo:bar-*,*-sa1:sa2", "*:*"]
+)
+def test_correct_namespaces_service_accounts(value: str) -> None:
+    # Given
+    # When
+    # Then
+    check_valid_values("monitored_service_accounts", value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ","  # coma
+        "foo:bar,",  # trailing coma
+        ",foo:bar",  # leading coma
+        " ",  # space
+        "foo:bar ",  # tailing space
+        " foo:bar",  # leading space
+        "foo:",  # missing sa
+        ":bar",  # missing ns
+        "foo:barsa1:sa2",  # missing separator
+    ],
+)
+def test_incorrect_namespaces_service_accounts(value: str) -> None:
+    # Given
+    # When
+    # Then
+    check_invalid_values("monitored_service_accounts", value)


### PR DESCRIPTION
This PR builds on https://github.com/canonical/spark-integration-hub-rock/pull/15 to implement a new configuration option `monitored-service-accounts` to restrict the integration-hub capabilities.

Following up on 
> I would be personally more in favor of restricting the syntax as much as possible on the charm side by removing all special chars but *

This is implemented in this PR, see the regular expression in `core/config.py` and the new tests in `test_config.py`.

Relation-based service accounts work as expected, as they automatically get added to the allowlist. We can see this from the unchanged `test_provider.py` file. spark-client-based service accounts now need to be explicitly allowed using this new configuration option, hence the changes in `test_charm.py`.