### PR TITLE
[PRA-113] Add a config option to specify custom Spark image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,6 @@ options:
     description: |
       Define a custom Spark image to be used for driver and executor pods.
       If this option is set, the integration hub will supply the related application with an additional Spark
-      property to use this image for drivers and executors. If not set, it's upto the related application to 
+      property to use this image for drivers and executors. If not set, it's up to the related application to 
       choose what image to use for the driver and executor pods.
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -44,3 +44,12 @@ options:
       Ex.: "namespace1:sa1,namespace2:*".
 
     default: ""
+
+  spark-image:
+    type: string
+    description: |
+      Define a custom Spark image to be used for driver and executor pods.
+      If this option is set, the integration hub will supply the related application with an additional Spark
+      property to use this image for drivers and executors. If not set, it's upto the related application to 
+      choose what image to use for the driver and executor pods.
+    default: ""

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -20,6 +20,7 @@ class CharmConfig(BaseConfigModel):
     driver_pod_template: str
     executor_pod_template: str
     monitored_service_accounts: list[str] = Field(default="")
+    spark_image: str
 
     @validator("monitored_service_accounts", pre=True)
     @classmethod

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -144,6 +144,12 @@ class IntegrationHubConfig(WithLogging):
                     "spark.kubernetes.executor.podTemplateFile": ept,
                 }
             )
+        if spark_image := self.hub_conf.spark_image:
+            hub_conf.update(
+                {
+                    "spark.kubernetes.container.image": spark_image,
+                }
+            )
 
         return hub_conf
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,7 +4,6 @@
 
 
 import logging
-import time
 from pathlib import Path
 
 import jubilant

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -420,6 +420,9 @@ def test_config_changed_properties_updated(
         "s3://my-bucket/executor.yaml"
     )
     charm_configuration["options"]["enable-dynamic-allocation"]["default"] = "true"
+    charm_configuration["options"]["spark-image"]["default"] = (
+        "ghcr.io/canonical/charmed-spark:3.5-22.04_edge"
+    )
     ctx = Context(SparkIntegrationHub, meta=METADATA, config=charm_configuration, unit_id=0)
     state = State(relations=[], containers=[integration_hub_container])
 
@@ -441,3 +444,7 @@ def test_config_changed_properties_updated(
         == "s3://my-bucket/executor.yaml"
     )
     assert "spark.dynamicAllocation.enabled" in spark_properties
+    assert (
+        spark_properties.get("spark.kubernetes.container.image", "")
+        == "ghcr.io/canonical/charmed-spark:3.5-22.04_edge"
+    )


### PR DESCRIPTION
Fixes #132.

The PR adds a new config option `spark-image` that translates to a spark property `spark.kubernetes.container.image`.