### PR TITLE
[PRA-152] Serialize asterisk characters when generating resource manifest

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Literal, TypedDict, Union, cast
 from lightkube.codecs import AnyResource, dump_all_yaml
 from lightkube.resources.core_v1 import Secret
 from spark8t.literals import HUB_LABEL
+from spark8t.utils import PercentEncodingSerializer
 
 PathLike = Union[str, "os.PathLike[str]"]
 
@@ -82,6 +83,9 @@ def get_hub_secret_manifest(
     secret_name = f"{HUB_LABEL}-{username}"
     if configurations is None:
         configurations = {}
+    serialized_config = {
+        PercentEncodingSerializer().serialize(key): value for key, value in configurations.items()
+    }
     secret = Secret.from_dict(
         {
             "apiVersion": "v1",
@@ -91,7 +95,7 @@ def get_hub_secret_manifest(
                 "namespace": namespace,
                 "labels": {"app.kubernetes.io/generated-by": "integration-hub"},
             },
-            "stringData": configurations,
+            "stringData": serialized_config,
         }
     )
     manifest = dump_all_yaml([cast(AnyResource, secret)]) or ""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,7 @@ from ops import pebble
 from ops.testing import Container, Context, Model, Mount, Relation
 
 from charm import SparkIntegrationHub
-from constants import CONTAINER, LOGGING_RELATION_NAME
+from constants import CONTAINER, INTEGRATION_HUB_REL, LOGGING_RELATION_NAME, PUSHGATEWAY
 from core.context import AZURE_RELATION_NAME, S3_RELATION_NAME
 
 
@@ -149,6 +149,48 @@ def logging_relation():
         remote_units_data={
             0: {
                 "endpoint": '{"url": "http://grafana-agent-k8s-0.grafana-agent-k8s-endpoints.spark.svc.cluster.local:3500/loki/api/v1/push"}'
+            }
+        },
+    )
+
+
+@pytest.fixture
+def pushgateway_relation():
+    """Provide fixture for the pushgateway relation."""
+    return Relation(
+        endpoint=PUSHGATEWAY,
+        interface="pushgateway",
+        remote_app_name="pushgateway",
+        remote_app_data={
+            "push-endpoint": '{"url": "http://pushgateway-0.pushgateway-endpoints.spark.svc.cluster.local:9091/"}'
+        },
+        remote_units_data={
+            0: {
+                "egress-subnets": "10.0.144.240/32",
+                "ingress-address": "10.0.144.240",
+                "private-address": "10.0.144.240",
+            }
+        },
+    )
+
+
+@pytest.fixture
+def spark_service_account_provider_relation():
+    """Provide fixture for the spark-service-account provider relation."""
+    return Relation(
+        endpoint=INTEGRATION_HUB_REL,
+        interface="spark_service_account",
+        remote_app_name="remote-app",
+        remote_app_data={
+            "skip-creation": "true",
+            "requested-secrets": '["foobar"]',
+            "service-account": "foo:bar",
+        },
+        remote_units_data={
+            0: {
+                "egress-subnets": "10.0.144.240/32",
+                "ingress-address": "10.0.144.240",
+                "private-address": "10.0.144.240",
             }
         },
     )

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -23,9 +23,11 @@ def charm_configuration():
     return json.loads(json.dumps(CONFIG))
 
 
+@patch("managers.s3.S3Manager.verify", return_value=True)
 @patch("workload.IntegrationHub.exec", return_value="")
 def test_props_serialization_in_resource_manifest(
     mock_exec_calls,
+    mock_s3_verify,
     integration_hub_ctx: Context[SparkIntegrationHub],
     integration_hub_container: Container,
     pushgateway_relation: Relation,
@@ -51,9 +53,13 @@ def test_props_serialization_in_resource_manifest(
     relations = list(out.relations)
     relations.append(pushgateway_relation)
     state_in = dataclasses.replace(out, relations=relations)
-    state_out = integration_hub_ctx.run(
-        integration_hub_ctx.on.relation_changed(pushgateway_relation), state_in
-    )
+    with (
+        patch("managers.k8s.KubernetesManager.__init__", return_value=None),
+        patch("managers.k8s.KubernetesManager.trusted", return_value=True),
+    ):
+        state_out = integration_hub_ctx.run(
+            integration_hub_ctx.on.relation_changed(pushgateway_relation), state_in
+        )
 
     assert state_out.unit_status == ActiveStatus("")
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Canonical Limited
+# See LICENSE file for licensing details.
+
+import dataclasses
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops import ActiveStatus
+from ops.testing import Container, Context, Relation, State
+
+from charm import SparkIntegrationHub
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def charm_configuration():
+    """Enable direct mutation on configuration dict."""
+    return json.loads(json.dumps(CONFIG))
+
+
+@patch("workload.IntegrationHub.exec", return_value="")
+def test_props_serialization_in_resource_manifest(
+    mock_exec_calls,
+    integration_hub_ctx: Context[SparkIntegrationHub],
+    integration_hub_container: Container,
+    pushgateway_relation: Relation,
+    spark_service_account_provider_relation,
+) -> None:
+    """Test the prop keys are properly serialized, specially when the keys may contain asterisk (*) character."""
+    state = State(
+        relations=[spark_service_account_provider_relation],
+        containers=[integration_hub_container],
+        leader=True,
+    )
+
+    with (
+        patch("managers.k8s.KubernetesManager.__init__", return_value=None),
+        patch("managers.k8s.KubernetesManager.trusted", return_value=True),
+    ):
+        out = integration_hub_ctx.run(
+            integration_hub_ctx.on.relation_changed(spark_service_account_provider_relation), state
+        )
+
+    assert out.unit_status == ActiveStatus("")
+
+    relations = list(out.relations)
+    relations.append(pushgateway_relation)
+    state_in = dataclasses.replace(out, relations=relations)
+    state_out = integration_hub_ctx.run(
+        integration_hub_ctx.on.relation_changed(pushgateway_relation), state_in
+    )
+
+    assert state_out.unit_status == ActiveStatus("")
+
+    app_data = state_out.get_relation(spark_service_account_provider_relation.id).local_app_data
+    spark_properties = json.loads(app_data.get("spark-properties", "{}"))
+    resource_manifest = yaml.safe_load(app_data.get("resource-manifest", ""))
+
+    # The spark-properties keys should send as-is, without serialization
+    assert "spark.metrics.conf.*.sink.prometheus.pushgateway-address" in spark_properties
+    assert "spark.metrics.conf.*.sink.prometheus.class" in spark_properties
+
+    # The resource-manifest keys should be serialized, so asterisk (*) becomes _2A
+    assert "spark.metrics.conf.*.sink.prometheus.class" not in resource_manifest["stringData"]
+    assert (
+        "spark.metrics.conf.*.sink.prometheus.pushgateway-address"
+        not in resource_manifest["stringData"]
+    )
+    assert (
+        "spark.metrics.conf._2A.sink.prometheus.pushgateway-address"
+        in resource_manifest["stringData"]
+    )
+    assert "spark.metrics.conf._2A.sink.prometheus.class" in resource_manifest["stringData"]


### PR DESCRIPTION
Fixes #143 

This will solve the issue of `resource-dispatcher` not being able to apply secret resources where the content key may contain `*` character.