### PR TITLE
[MISC] Update the constraint to support juju >= 3.6.13

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,9 @@ maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 assumes:
   - k8s-api
-  - juju < 3.6.10
+  - any-of:
+    - juju < 3.6.10
+    - juju >= 3.6.13
 
 containers:
   integration-hub:


### PR DESCRIPTION
Now that https://github.com/juju/juju/pull/21477 has been merged and juju 3.6.13 has been released, we want to remove the pinning on Juju 3.6.9.