### PR TITLE
[PRA-200] Explicit proxy support for S3-compliant storage

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -4,9 +4,11 @@
 
 """Utilities."""
 
+import ipaddress
 import os
 from logging import Logger, getLogger
 from typing import Any, Callable, Literal, TypedDict, Union, cast
+from urllib.parse import urlparse
 
 from lightkube.codecs import AnyResource, dump_all_yaml
 from lightkube.resources.core_v1 import Secret
@@ -100,3 +102,35 @@ def get_hub_secret_manifest(
     )
     manifest = dump_all_yaml([cast(AnyResource, secret)]) or ""
     return manifest
+
+
+def is_proxy_skipped(endpoint: str) -> bool:
+    """Determine if proxy should not be applied for the given endpoint."""
+    no_proxy_list = os.environ.get("JUJU_CHARM_NO_PROXY", "")
+    if not no_proxy_list:
+        return False
+
+    host = urlparse(endpoint).hostname
+    if not host:
+        return False
+    no_proxy_entries = [
+        entry.strip().lower() for entry in no_proxy_list.split(",") if entry.strip()
+    ]
+    for entry in no_proxy_entries:
+        if host == entry:
+            return True
+        elif entry.startswith(".") and host.endswith(
+            entry
+        ):  # abc.example.com matches .example.com
+            return True
+        elif host.endswith("." + entry):  # abc.example.com matches example.com
+            return True
+        try:
+            if ipaddress.ip_address(host) in ipaddress.ip_network(
+                entry, strict=False
+            ):  # CIDR match
+                return True
+        except (AttributeError, ValueError):
+            continue
+
+    return False

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -62,9 +62,9 @@ class S3ConnectionInfo(StateBase):
         super().__init__(relation, component)
 
     @property
-    def endpoint(self) -> str | None:
+    def endpoint(self) -> str:
         """Return endpoint of the S3 bucket."""
-        return self.relation_data.get("endpoint", None)
+        return self.relation_data.get("endpoint", "")
 
     @property
     def access_key(self) -> str:

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -68,17 +68,18 @@ class IntegrationHubConfig(WithLogging):
             return {
                 "spark.hadoop.fs.s3a.path.style.access": "true",
                 "spark.eventLog.enabled": "true",
-                "spark.hadoop.fs.s3a.endpoint": s3.config.endpoint or "https://s3.amazonaws.com",
-                "spark.hadoop.fs.s3a.access.key": s3.config.access_key,
-                "spark.hadoop.fs.s3a.secret.key": s3.config.secret_key,
-                "spark.eventLog.dir": s3.config.log_dir,
-                "spark.history.fs.logDirectory": s3.config.log_dir,
+                "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
+                or "https://s3.amazonaws.com",
+                "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
+                "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
+                "spark.eventLog.dir": s3.connection_info.log_dir,
+                "spark.history.fs.logDirectory": s3.connection_info.log_dir,
                 "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
                 "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
-                    s3.config.endpoint
+                    s3.connection_info.endpoint
                 ),
-                "spark.kubernetes.file.upload.path": s3.config.file_upload_path,
-                "spark.sql.warehouse.dir": s3.config.warehouse_path,
+                "spark.kubernetes.file.upload.path": s3.connection_info.file_upload_path,
+                "spark.sql.warehouse.dir": s3.connection_info.warehouse_path,
             }
         return {}
 

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -86,17 +86,12 @@ class IntegrationHubConfig(WithLogging):
             "spark.sql.warehouse.dir": s3.connection_info.warehouse_path,
         }
 
-        # Assigns the first non empty proxy url or defaults to an empty string
-        proxy_url = next(
-            filter(
-                None,
-                (
-                    os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-                    os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-                ),
-            ),
-            "",
-        )
+        s3_scheme = urlparse(s3.connection_info.endpoint).scheme
+        proxy_url = {
+            "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+        }.get(s3_scheme, os.environ.get("JUJU_CHARM_HTTP_PROXY", ""))
+
         if is_proxy_skipped(s3.connection_info.endpoint):
             proxy_conf: dict[str, str] = {}
         else:

--- a/src/managers/integration_hub.py
+++ b/src/managers/integration_hub.py
@@ -4,9 +4,11 @@
 
 """Integration Hub manager."""
 
+import os
 import re
+from urllib.parse import ParseResult, urlparse
 
-from common.utils import WithLogging, get_hub_secret_manifest
+from common.utils import WithLogging, get_hub_secret_manifest, is_proxy_skipped
 from core.config import CharmConfig
 from core.context import Context
 from core.domain import (
@@ -64,24 +66,79 @@ class IntegrationHubConfig(WithLogging):
 
     @property
     def _s3_conf(self) -> dict[str, str]:
-        if (s3 := self.s3) and s3.verify():
-            return {
-                "spark.hadoop.fs.s3a.path.style.access": "true",
-                "spark.eventLog.enabled": "true",
-                "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
-                or "https://s3.amazonaws.com",
-                "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
-                "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
-                "spark.eventLog.dir": s3.connection_info.log_dir,
-                "spark.history.fs.logDirectory": s3.connection_info.log_dir,
-                "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-                "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
-                    s3.connection_info.endpoint
+        if (s3 := self.s3) is None or not s3.verify():
+            return {}
+
+        base_s3_conf = {
+            "spark.hadoop.fs.s3a.path.style.access": "true",
+            "spark.eventLog.enabled": "true",
+            "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
+            or "https://s3.amazonaws.com",
+            "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
+            "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
+            "spark.eventLog.dir": s3.connection_info.log_dir,
+            "spark.history.fs.logDirectory": s3.connection_info.log_dir,
+            "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
+            "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
+                s3.connection_info.endpoint
+            ),
+            "spark.kubernetes.file.upload.path": s3.connection_info.file_upload_path,
+            "spark.sql.warehouse.dir": s3.connection_info.warehouse_path,
+        }
+
+        # Assigns the first non empty proxy url or defaults to an empty string
+        proxy_url = next(
+            filter(
+                None,
+                (
+                    os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+                    os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
                 ),
-                "spark.kubernetes.file.upload.path": s3.connection_info.file_upload_path,
-                "spark.sql.warehouse.dir": s3.connection_info.warehouse_path,
-            }
-        return {}
+            ),
+            "",
+        )
+        if is_proxy_skipped(s3.connection_info.endpoint):
+            proxy_conf: dict[str, str] = {}
+        else:
+            match urlparse(proxy_url):
+                case ParseResult(
+                    username=str(username),
+                    password=str(password),
+                    hostname=str(hostname),
+                    port=port,
+                    scheme=scheme,
+                ) if scheme in ("http", "https"):
+                    port_str = str(port) if port else {"http": "80", "https": "443"}[scheme]
+                    proxy_conf = {
+                        "spark.hadoop.fs.s3a.proxy.host": hostname,
+                        "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
+                        if scheme == "https"
+                        else "false",
+                        "spark.hadoop.fs.s3a.proxy.port": port_str,
+                        "spark.hadoop.fs.s3a.proxy.username": username,
+                        "spark.hadoop.fs.s3a.proxy.password": password,
+                    }
+
+                case ParseResult(
+                    username=None,
+                    password=None,
+                    hostname=str(hostname),
+                    port=port,
+                    scheme=scheme,
+                ) if scheme in ("http", "https"):
+                    port_str = str(port) if port else {"http": "80", "https": "443"}[scheme]
+                    proxy_conf = {
+                        "spark.hadoop.fs.s3a.proxy.host": hostname,
+                        "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
+                        if scheme == "https"
+                        else "false",
+                        "spark.hadoop.fs.s3a.proxy.port": port_str,
+                    }
+
+                case _:
+                    proxy_conf = {}
+
+        return base_s3_conf | proxy_conf
 
     @property
     def _azure_storage_conf(self) -> dict[str, str]:

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -17,29 +17,29 @@ from core.domain import S3ConnectionInfo
 class S3Manager(WithLogging):
     """Class exposing business logic for interacting with S3 service."""
 
-    def __init__(self, config: S3ConnectionInfo):
-        self.config = config
+    def __init__(self, connection_info: S3ConnectionInfo):
+        self.connection_info = connection_info
 
     @cached_property
     def session(self):
         """Return the S3 session to be used when connecting to S3."""
         return boto3.session.Session(
-            aws_access_key_id=self.config.access_key,
-            aws_secret_access_key=self.config.secret_key,
+            aws_access_key_id=self.connection_info.access_key,
+            aws_secret_access_key=self.connection_info.secret_key,
         )
 
     def verify(self) -> bool:
         """Verify S3 credentials."""
         with tempfile.NamedTemporaryFile() as ca_file:
-            if config := self.config.tls_ca_chain:
+            if config := self.connection_info.tls_ca_chain:
                 ca_file.write("\n".join(config).encode())
                 ca_file.flush()
 
             s3 = self.session.client(
                 "s3",
-                region_name=self.config.region or "us-east-1",
-                endpoint_url=self.config.endpoint or "https://s3.amazonaws.com",
-                verify=ca_file.name if self.config.tls_ca_chain else None,
+                region_name=self.connection_info.region or "us-east-1",
+                endpoint_url=self.connection_info.endpoint or "https://s3.amazonaws.com",
+                verify=ca_file.name if self.connection_info.tls_ca_chain else None,
             )
 
             try:

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -4,13 +4,15 @@
 
 """S3 manager."""
 
+import os
 import tempfile
 from functools import cached_property
 
 import boto3
+from botocore.client import Config
 from botocore.exceptions import ClientError, SSLError
 
-from common.utils import WithLogging
+from common.utils import WithLogging, is_proxy_skipped
 from core.domain import S3ConnectionInfo
 
 
@@ -30,6 +32,14 @@ class S3Manager(WithLogging):
 
     def verify(self) -> bool:
         """Verify S3 credentials."""
+        proxy_config: dict[str, str] = {}
+
+        if not is_proxy_skipped(self.connection_info.endpoint or ""):
+            if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
+                proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
+            if os.environ.get("JUJU_CHARM_HTTP_PROXY"):
+                proxy_config["http"] = os.environ["JUJU_CHARM_HTTP_PROXY"]
+
         with tempfile.NamedTemporaryFile() as ca_file:
             if tls_ca_chain := self.connection_info.tls_ca_chain:
                 ca_file.write("\n".join(tls_ca_chain).encode())
@@ -40,6 +50,11 @@ class S3Manager(WithLogging):
                 region_name=self.connection_info.region or "us-east-1",
                 endpoint_url=self.connection_info.endpoint or "https://s3.amazonaws.com",
                 verify=ca_file.name if self.connection_info.tls_ca_chain else None,
+                config=Config(
+                    request_checksum_calculation="when_supported",
+                    response_checksum_validation="when_supported",
+                    proxies=proxy_config,
+                ),
             )
 
             try:

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -31,8 +31,8 @@ class S3Manager(WithLogging):
     def verify(self) -> bool:
         """Verify S3 credentials."""
         with tempfile.NamedTemporaryFile() as ca_file:
-            if config := self.connection_info.tls_ca_chain:
-                ca_file.write("\n".join(config).encode())
+            if tls_ca_chain := self.connection_info.tls_ca_chain:
+                ca_file.write("\n".join(tls_ca_chain).encode())
                 ca_file.flush()
 
             s3 = self.session.client(

--- a/tests/unit/test_component_hub_manager.py
+++ b/tests/unit/test_component_hub_manager.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Canonical Limited
+# See LICENSE file for licensing details
+
+from dataclasses import dataclass
+from unittest import mock
+
+from pytest import MonkeyPatch
+
+from managers.integration_hub import IntegrationHubConfig
+
+
+@dataclass
+class S3InfoTester:
+    endpoint: str = "https://192.168.1.1"
+    access_key: str = "foo"
+    secret_key: str = "bar"
+    bucket: str = "bucket"
+    path: str = "path/"
+    region: str = ""
+    tls_ca_chain: str = ""
+    log_dir: str = ""
+    file_upload_path: str = ""
+    warehouse_path: str = ""
+
+
+def test_s3_proxy_credentials(monkeypatch: MonkeyPatch) -> None:
+    """Proxy credentials are properly extracted and passed to the spark properties."""
+    # Given
+    monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://username:password@10.152.193.234:80")
+
+    with mock.patch("managers.integration_hub.S3Manager", mock.MagicMock()) as mocked_s3_manager:
+        mocked_s3_manager.connection_info = S3InfoTester()
+        config = IntegrationHubConfig(object(), None, None, None, None)  # type: ignore
+
+        # When
+        s3_proxy_conf = config._s3_conf
+
+    # Then
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.username", "") == "username"
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.password", "") == "password"
+
+
+def test_s3_proxy_plain_ip(monkeypatch: MonkeyPatch) -> None:
+    """Proper scheme and port are passed to the spark properties.
+
+    Even if https_proxy is pointing to an http domain.
+    """
+    # Given
+    proxy_host = "10.152.193.234"
+    monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", f"http://{proxy_host}")
+
+    with mock.patch("managers.integration_hub.S3Manager", mock.MagicMock()) as mocked_s3_manager:
+        mocked_s3_manager.connection_info = S3InfoTester()
+        config = IntegrationHubConfig(object(), None, None, None, None)  # type: ignore
+
+        # When
+        s3_proxy_conf = config._s3_conf
+
+    # Then
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.host", "") == proxy_host
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.ssl.enabled", "") == "false"
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.port", "0") == "80"

--- a/tests/unit/test_component_hub_manager.py
+++ b/tests/unit/test_component_hub_manager.py
@@ -11,7 +11,7 @@ from managers.integration_hub import IntegrationHubConfig
 
 @dataclass
 class S3InfoTester:
-    endpoint: str = "https://192.168.1.1"
+    endpoint: str = "http://192.168.1.1"
     access_key: str = "foo"
     secret_key: str = "bar"
     bucket: str = "bucket"
@@ -29,7 +29,8 @@ def test_s3_proxy_credentials(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://username:password@10.152.193.234:80")
 
     with mock.patch("managers.integration_hub.S3Manager", mock.MagicMock()) as mocked_s3_manager:
-        mocked_s3_manager.connection_info = S3InfoTester()
+        instance = mocked_s3_manager.return_value
+        instance.connection_info = S3InfoTester()
         config = IntegrationHubConfig(object(), None, None, None, None)  # type: ignore
 
         # When
@@ -47,10 +48,11 @@ def test_s3_proxy_plain_ip(monkeypatch: MonkeyPatch) -> None:
     """
     # Given
     proxy_host = "10.152.193.234"
-    monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", f"http://{proxy_host}")
+    monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", f"http://{proxy_host}")
 
     with mock.patch("managers.integration_hub.S3Manager", mock.MagicMock()) as mocked_s3_manager:
-        mocked_s3_manager.connection_info = S3InfoTester()
+        instance = mocked_s3_manager.return_value
+        instance.connection_info = S3InfoTester()
         config = IntegrationHubConfig(object(), None, None, None, None)  # type: ignore
 
         # When

--- a/tests/unit/test_component_utils.py
+++ b/tests/unit/test_component_utils.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Canonical Limited
+# See LICENSE file for licensing details
+import pytest
+
+from common.utils import is_proxy_skipped
+
+
+@pytest.mark.parametrize(
+    "no_proxy_env, endpoint, expected",
+    [
+        # Exact hostname match
+        ("example.com", "https://example.com", True),
+        # Domain suffix match
+        (".example.com", "https://sub.example.com", True),
+        # Subdomain match
+        ("example.com", "https://sub.example.com", True),
+        # Host not in no_proxy
+        ("example.com", "https://other.com", False),
+        # IP exact match
+        ("10.1.1.1", "https://10.1.1.1", True),
+        # IP in CIDR
+        ("10.0.0.0/8", "https://10.152.183.1", True),
+        # IP outside CIDR
+        ("10.0.0.0/8", "https://192.168.1.1", False),
+        # Multiple entries in no_proxy
+        ("127.0.0.1,example.com,10.0.0.0/8", "https://10.5.5.5", True),
+        ("127.0.0.1,example.com,10.0.0.0/8", "https://192.168.1.1", False),
+        # Empty no_proxy
+        ("", "https://anything.com", False),
+        # Localhost and loopback IPs
+        ("127.0.0.1,localhost,::1", "http://127.0.0.1", True),
+        ("127.0.0.1,localhost,::1", "http://localhost", True),
+        ("127.0.0.1,localhost,::1", "http://[::1]", True),
+        ("127.0.0.1,localhost,::1", "http://10.0.0.1", False),
+        # Empty endpoint or missing hostname
+        ("example.com", "", False),
+        ("example.com", "file:///tmp/file.txt", False),
+        # Wildcard subdomain edge
+        (".example.com", "https://deep.sub.example.com", True),
+        # Multiple domains / IPs with whitespace
+        (" example.com , 10.0.0.0/8 ,localhost ", "https://10.12.34.56", True),
+        (" example.com , 10.0.0.0/8 ,localhost ", "https://otherhost.com", False),
+        # Invalid CIDR entries (should be ignored)
+        ("10.0.0.0/8,invalid_cidr,example.com", "https://10.1.2.3", True),
+        ("10.0.0.0/8,invalid_cidr,example.com", "https://notexample.com", False),
+        # Endpoint with port number
+        ("example.com", "https://example.com:8080/path", True),
+        ("example.com", "https://other.com:443/path", False),
+        # Mixed case domain (should be case-insensitive)
+        ("EXAMPLE.COM", "https://example.com", True),
+        ("EXAMPLE.COM", "https://Sub.Example.Com", True),
+    ],
+)
+def test_skip_proxy(no_proxy_env, endpoint, expected, monkeypatch):
+    # Given
+    # Patch JUJU_CHARM_NO_PROXY env var
+    monkeypatch.setenv("JUJU_CHARM_NO_PROXY", no_proxy_env)
+
+    # When
+    should_skip_proxy = is_proxy_skipped(endpoint)
+
+    # Then
+    assert should_skip_proxy == expected

--- a/tests/unit/test_component_utils.py
+++ b/tests/unit/test_component_utils.py
@@ -52,6 +52,7 @@ from common.utils import is_proxy_skipped
     ],
 )
 def test_skip_proxy(no_proxy_env, endpoint, expected, monkeypatch):
+    """Test that we are properly detecting that we should skip domains given a NO_PROXY env var."""
     # Given
     # Patch JUJU_CHARM_NO_PROXY env var
     monkeypatch.setenv("JUJU_CHARM_NO_PROXY", no_proxy_env)


### PR DESCRIPTION
Similar to https://github.com/canonical/spark-history-server-k8s-operator/pull/143, this PR aims to address the issue we've been facing on PS7.

## Changes

- Added the fix mentioned above, proxy config is explicitly passed as an empty dict to the boto library if the endpoint is included in NO_PROXY.
- Reworked the hub's spark properties if we need to access the object storage through a proxy
- Reworded a few variables because everything was named "config"

Like the PR linked above, this work does not include Azure storage.

## Testing 
- The NO_PROXY issue was successfully tested on PS7 with a local storage
- Using AWS S3 on PS7 through a proxy was successful as well

I was able to deploy two s3-integrators, one pointing to AWS and one pointing to a local microceph. By integrating one hub monitoring my service account with one s3 and then integrating with the other, Spark jobs successfully sent their logs to both S3 storages with the correct proxy configuration.
