### PR TITLE
[PRA-73] Restore Juju 3.6.13+ compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.6/stable
-          bootstrap-options: "--agent-version 3.6.9"
           provider: microk8s
           channel: 1.32-strict/stable
           microk8s-group: snap_microk8s

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,9 @@ maintainers:
   - Canonical Data Platform <data-platform@lists.launchpad.net>
 assumes:
   - k8s-api
-  - juju < 3.6.10
+  - any-of:
+      - juju < 3.6.10
+      - juju >= 3.6.13
 
 containers:
   integration-hub:
@@ -32,7 +34,7 @@ resources:
   integration-hub-image:
     type: oci-image
     description: OCI image for the Spark Integration Hub Charm
-    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:d41c40f3e5d561ce80cce1906af5bd5e1497a878468fde1e06a8aad8cca18b7d # 3-22.04 2026-01-21
+    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:2e31e78ac9eb9509d2cbbc233fbb62efe34966b8f9bcf5d862e17e7182637c7e # 3-22.04 2026-02-18
 
 requires:
   s3-credentials:


### PR DESCRIPTION
This PR brings back compatibility with newer Juju agent releases by updating the OCI resource to the newly released integration hub rock with spark8t 1.3.0.
