### PR TITLE
[PRA-158] Update OCI resource to latest release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,7 @@ description: |
   charmed components and allows simple configuration of Spark jobs and
   integration with client applications, abstracting low-level configuration
   option settings.
-docs: https://discourse.charmhub.io/t/integration-hub-for-apache-spark-documentation/16751
+docs: https://canonical-charmed-spark.readthedocs-hosted.com/main/how-to/manage-service-accounts/using-integration-hub
 source: https://github.com/canonical/spark-integration-hub-k8s-operator
 issues: https://github.com/canonical/spark-integration-hub-k8s-operator/issues
 website:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,7 @@ resources:
   integration-hub-image:
     type: oci-image
     description: OCI image for the Spark Integration Hub Charm
-    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:2e31e78ac9eb9509d2cbbc233fbb62efe34966b8f9bcf5d862e17e7182637c7e # 3-22.04 2026-02-18
+    upstream-source: ghcr.io/canonical/spark-integration-hub@sha256:c04d2d95874612883f6ead105d5f1dd74230370b23a08ea81175df81ba2e06fa # 3-22.04 2026-03-02
 
 requires:
   s3-credentials:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1149,14 +1149,14 @@ files = [
 
 [[package]]
 name = "spark8t"
-version = "1.3.0"
+version = "1.3.1"
 description = "This project provides some utilities function and CLI commands to run Spark on K8s."
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "spark8t-1.3.0-py3-none-any.whl", hash = "sha256:4081639a67043b57d721e8fa0bd0034eff268f9e1799089ce7379a656fc20396"},
-    {file = "spark8t-1.3.0.tar.gz", hash = "sha256:cb5471c04e966887eca8f8308ffae84f59fd495c2a1614d4b0ac067f6d18949c"},
+    {file = "spark8t-1.3.1-py3-none-any.whl", hash = "sha256:53f6840a4ecff838e4dc86fd545f3e6ae1c124fb46fd0fb197eb8e10ce51ffb7"},
+    {file = "spark8t-1.3.1.tar.gz", hash = "sha256:4b1a1a220f4a44024c00feb6429c78bec55af162d8b87bbe88d96e3ccb5f7a75"},
 ]
 
 [package.dependencies]
@@ -1810,4 +1810,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.10,<4.0"
-content-hash = "b787cef701d21fc6a3efec8852de0781d80a009131808df0f1518e332e8dcc2b"
+content-hash = "4e17ea0ee4bd2c776664d97489b4509157056f476e4efcab4ca332391cbc3d4f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">3.10,<4.0"
 ops = "^3.5.2"
 boto3 = ">=1.42.49,<1.43"
 lightkube = "0.19.1"
-spark8t = "^1.3.0"
+spark8t = "^1.3.1"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = "^3.0"

--- a/tests/integration/setup/run_spark_job.sh
+++ b/tests/integration/setup/run_spark_job.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-spark-client.spark-submit -v --username $1 --namespace $2 --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar 10000
+spark-client.spark-submit -v --username $1 --namespace $2 --conf spark.kubernetes.executor.request.cores=0.1 --class org.apache.spark.examples.SparkPi local:///opt/spark/examples/jars/spark-examples_2.12-3.5.7.jar 10000

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,16 @@
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = lint, unit
+env_list =
+    refresh
+    format
+    lint
+    unit
+    build-charms
+    integration-charm
+    integration-provider
+    integration-observability
+    integration-trust
 
 [vars]
 application = spark-integration-hub-k8s-operator
@@ -95,6 +104,10 @@ description = Run integration tests
 pass_env =
     {[testenv]pass_env}
     CI
+    S3_ACCESS_KEY
+    S3_SECRET_KEY
+    S3_SERVER_URL
+    S3_CA_BUNDLE_PATH
 commands =
     poetry install --with integration
     poetry run pytest -x -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/{env:TEST_FILE}


### PR DESCRIPTION
## Changes

- Bump spark8t to 1.3.1, including in the OCI resource
- Two minor updates to tox.ini and metadata.yaml to make it easier to test locally and to link to the new RTD docs
