### PR TITLE
[PRA-63] Run integration tests using spread

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ on:
         description: build_charm.yaml `artifact-prefix` output
         value: ${{ jobs.build.outputs.artifact-prefix }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -52,78 +55,16 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.1
     with:
       path-to-charm-directory: ${{ matrix.path }}
+    permissions:
+      actions: read
+      contents: read
 
   integration-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        system:
-          - os: ubuntu-22.04
-            arch: amd64
-          - os: ubuntu-22.04-arm
-            arch: arm64
-        tox-environments:
-          - integration-charm
-          - integration-provider
-          - integration-observability
-          - integration-trust
-          - integration-tls
-        exclude:
-          - tox-environments: integration-observability # No ARM build for obs charms
-            system:
-              os: ubuntu-22.04-arm
-              arch: arm64
-
-    name: ${{ matrix.tox-environments }} (${{ matrix.system.arch }})
+    name: Integration tests
     needs:
       - lint
       - unit-test
       - build
-    runs-on: ${{ matrix.system.os }}
-    timeout-minutes: 120
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup operator environment
-        # TODO: Replace with custom image on self-hosted runner
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.6/stable
-          provider: microk8s
-          channel: 1.32-strict/stable
-          microk8s-group: snap_microk8s
-          microk8s-addons: "rbac hostpath-storage dns"
-
-      - name: Setup microceph
-        id: microceph
-        run: |
-          sudo snap install microceph
-          sudo microceph cluster bootstrap
-          sudo microceph disk add loop,1G,3
-          sudo microceph enable rgw
-          sleep 15
-          sudo microceph.radosgw-admin user create --uid test --display-name test --access-key=foo --secret-key=bar
-          echo -e "S3_SERVER_URL=http://$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc'):80/\nS3_ACCESS_KEY=foo\nS3_SECRET_KEY=bar" > .env
-
-      - name: Download packed charm(s)
-        uses: actions/download-artifact@v8
-        with:
-          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
-          merge-multiple: true
-
-      - name: Select tests
-        id: select-tests
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]
-          then
-            echo Running unstable and stable tests
-            echo "mark_expression=" >> $GITHUB_OUTPUT
-          else
-            echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Run integration tests
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-        env:
-          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+    uses: ./.github/workflows/integration_test.yaml
+    with:
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -87,12 +87,27 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Free up disk space
-        timeout-minutes: 2
+        timeout-minutes: 10
         run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          rm -rf /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          printf '\nDisk usage\n'
           df --human-readable
       - name: Checkout
         timeout-minutes: 3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,149 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: |
+          Prefix for charm package GitHub artifact(s)
+
+          Use canonical/data-platform-workflows build_charm.yaml to build the charm(s)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  collect-integration-tests:
+    name: Collect integration test spread jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up spread
+        run: |
+          sudo snap install go --classic
+          go install github.com/canonical/spread/cmd/spread@latest
+      - name: Collect spread jobs
+        id: collect-jobs
+        shell: python
+        run: |
+          import json
+          import pathlib
+          import os
+          import subprocess
+
+          spread_jobs = (
+              subprocess.run(
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
+              )
+              .stdout.strip()
+              .split("\n")
+          )
+          jobs = []
+          for job in spread_jobs:
+              # Example job: "github-ci:ubuntu-22.04:tests/spread/integration-charm:juju36"
+              _, runner, task, variant = job.split(":")
+              # Example task: "integration-charm"
+              task = task.removeprefix("tests/spread/")
+              architecture = "arm64" if runner.endswith("-arm") else "amd64"
+
+              if architecture == "arm64" and task == "integration-observability":
+                  # No ARM build for observability charms
+                  continue
+
+              # Example: "integration-charm:juju36 | amd64"
+              name = f"{task}:{variant} | {architecture}"
+              # ":" character not valid in GitHub Actions artifact names
+              name_in_artifact = f"{task}-{variant}-{architecture}"
+              jobs.append({
+                  "spread_job": job,
+                  "name": name,
+                  "name_in_artifact": name_in_artifact,
+                  "runner": runner,
+              })
+          output = f"jobs={json.dumps(jobs)}"
+          print(output)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as file:
+              file.write(output)
+    outputs:
+      jobs: ${{ steps.collect-jobs.outputs.jobs }}
+
+  integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: ${{ fromJSON(needs.collect-integration-tests.outputs.jobs) }}
+    name: ${{ matrix.job.name }}
+    needs:
+      - collect-integration-tests
+    runs-on: ${{ matrix.job.runner }}
+    timeout-minutes: 150
+    steps:
+      - name: Free up disk space
+        timeout-minutes: 2
+        run: |
+          printf '\nDisk usage before cleanup\n'
+          df --human-readable
+          rm -rf /opt/hostedtoolcache/
+          printf '\nDisk usage after cleanup\n'
+          df --human-readable
+      - name: Checkout
+        timeout-minutes: 3
+        uses: actions/checkout@v6
+      - name: Set up spread
+        timeout-minutes: 5
+        # TODO: replace with `charmcraft test` when
+        # https://github.com/canonical/charmcraft/issues/2105 and
+        # https://github.com/canonical/charmcraft/issues/2130 are fixed
+        run: |
+          sudo snap install go --classic
+          go install github.com/canonical/spread/cmd/spread@latest
+      - name: Download packed charm(s)
+        timeout-minutes: 5
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+      - name: Run spread job
+        timeout-minutes: 120
+        id: spread
+        run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
+      - name: snap list
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: snap list
+      - name: Select model
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        id: juju-switch
+        run: |
+          # sudo needed since spread runs scripts as root
+          # "testing" is the default model created by concierge
+          sudo juju switch testing
+          mkdir ~/logs/
+      - name: juju status
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo juju status --color --relations | tee ~/logs/juju-status.txt
+      - name: juju debug-log
+        timeout-minutes: 3
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo juju debug-log --color --replay --no-tail | tee ~/logs/juju-debug-log.txt
+      - name: Disk usage
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: df --human-readable
+      - name: Upload logs
+        timeout-minutes: 2
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-${{ matrix.job.name_in_artifact }}
+          path: ~/logs/

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -22,4 +22,3 @@ host:
     charmcraft:
       channel: latest/stable
     microceph:
-      channel: latest/stable

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -4,6 +4,7 @@
 juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
+
 providers:
   microk8s:
     enable: true
@@ -13,6 +14,7 @@ providers:
       - dns
       - hostpath-storage
       - rbac
+
 host:
   packages:
     - pipx

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -18,6 +18,7 @@ providers:
 host:
   packages:
     - pipx
+    - jq
   snaps:
     charmcraft:
       channel: latest/stable

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+juju:
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
+providers:
+  microk8s:
+    enable: true
+    channel: 1.32-strict/stable
+    bootstrap: true
+    addons:
+      - dns
+      - hostpath-storage
+      - rbac
+host:
+  packages:
+    - pipx
+  snaps:
+    charmcraft:
+      channel: latest/stable
+    microceph:
+      channel: latest/stable

--- a/spread.yaml
+++ b/spread.yaml
@@ -5,6 +5,51 @@ project: spark-integration-hub-k8s-operator
 
 backends:
   # Derived from https://github.com/canonical/object-storage-integrator/blob/main/spread.yaml
+  lxd-vm:
+    # TODO: remove after https://github.com/canonical/spread/pull/185 merged & in charmcraft
+    type: adhoc
+    allocate: |
+      hash=$(python3 -c "import hashlib; print(hashlib.sha256('$SPREAD_PASSWORD'.encode()).hexdigest()[:6])")
+      VM_NAME="${VM_NAME:-${SPREAD_SYSTEM//./-}-${hash}}"
+      DISK="${DISK:-20}"
+      CPU="${CPU:-4}"
+      MEM="${MEM:-8}"
+
+      cloud_config="#cloud-config
+      ssh_pwauth: true
+      users:
+        - default
+        - name: runner
+          plain_text_passwd: $SPREAD_PASSWORD
+          lock_passwd: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+      "
+
+      lxc launch --vm \
+        "${SPREAD_SYSTEM//-/:}" \
+        "${VM_NAME}" \
+        -c user.user-data="${cloud_config}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+      # Wait for the runner user
+      while ! lxc exec "${VM_NAME}" -- id -u runner &>/dev/null; do sleep 0.5; done
+
+      # Set the instance address for spread
+      ADDRESS "$(lxc ls -f csv | grep "${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1)"
+    discard: |
+      hash=$(python3 -c "import hashlib; print(hashlib.sha256('$SPREAD_PASSWORD'.encode()).hexdigest()[:6])")
+      VM_NAME="${VM_NAME:-${SPREAD_SYSTEM//./-}-${hash}}"
+      lxc delete --force "${VM_NAME}"
+    systems:
+      - ubuntu-22.04:
+          username: runner
+    prepare: |
+      systemctl disable --now unattended-upgrades.service
+      systemctl mask unattended-upgrades.service
+      pipx install charmcraftcache
+
   github-ci:
     type: adhoc
     # Only run on CI
@@ -48,6 +93,7 @@ environment:
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
 
 prepare: |
+  sleep 5
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
@@ -69,6 +115,3 @@ prepare: |
 
   pipx install tox
   pipx install poetry
-
-restore: |
-  rm -rf "$SPREAD_PATH"

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+project: spark-integration-hub-k8s-operator
+
+backends:
+  # Derived from https://github.com/canonical/object-storage-integrator/blob/main/spread.yaml
+  github-ci:
+    type: adhoc
+    # Only run on CI
+    manual: true
+    # HACK: spread requires runners to be accessible via SSH
+    # Configure local sshd & instruct spread to connect to the same machine spread is running on
+    # (spread cannot provision GitHub Actions runners, so we provision a GitHub Actions runner for
+    # each spread job & select a single job when running spread)
+    allocate: |
+      sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
+      PasswordAuthentication yes
+      PermitEmptyPasswords yes
+      EOF
+
+      sudo systemctl daemon-reload
+      sudo systemctl restart ssh
+
+      sudo passwd --delete "$USER"
+
+      ADDRESS "127.0.0.1"
+    # HACK: spread does not pass environment variables set on runner
+    # Manually pass specific environment variables
+    environment:
+      CI: "$(HOST: echo $CI)"
+    systems:
+      - ubuntu-22.04:
+          username: runner
+      - ubuntu-22.04-arm:
+          username: runner
+
+suites:
+  tests/spread/:
+    summary: Integration tests for spark-integration-hub-k8s-operator
+
+path: /root/spread_project
+
+kill-timeout: 3h
+
+environment:
+  PATH: $PATH:/root/.local/bin:/opt/pipx_bin
+  CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+
+prepare: |
+  snap refresh --hold
+  chown -R root:root "$SPREAD_PATH"
+  cd "$SPREAD_PATH"
+
+  snap install --classic concierge
+  concierge prepare --trace
+
+  # Configure microceph for S3-backed integration tests
+  microceph cluster bootstrap
+  microceph disk add loop,1G,3
+  microceph enable rgw
+  sleep 15
+  microceph.radosgw-admin user create \
+    --uid test --display-name test \
+    --access-key=foo --secret-key=bar
+  S3_IP=$(ip -4 -j route get 2.2.2.2 | jq -r '.[0].prefsrc')
+  printf 'S3_SERVER_URL=http://%s:80/\nS3_ACCESS_KEY=foo\nS3_SECRET_KEY=bar\n' "$S3_IP" \
+    > "$SPREAD_PATH/.env"
+
+  pipx install tox
+  pipx install poetry
+
+restore: |
+  rm -rf "$SPREAD_PATH"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,12 @@ def pytest_addoption(parser):
         default=False,
         help="keep temporarily-created models",
     )
+    parser.addoption(
+        "--model",
+        action="store",
+        help="Juju model to use; if not provided, a new model "
+        "will be created for each test which requires one",
+    )
 
 
 @pytest.fixture
@@ -202,21 +208,29 @@ def test_charm(platform: str) -> Path:
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest, platform: str):
     keep_models = bool(request.config.getoption("--keep-models"))
+    model = request.config.getoption("--model")
+    model_name = str(model)
 
-    with jubilant.temp_model(keep=keep_models) as juju:
+    if model is None:
+        with jubilant.temp_model(keep=keep_models) as juju:
+            juju.wait_timeout = 10 * 60
+            juju.cli("set-model-constraints", f"arch={platform}")
+            yield juju
+
+    else:
+        juju = jubilant.Juju()
+        juju.model = model_name
+        try:
+            juju.status()
+        except jubilant.CLIError:
+            juju.add_model(model_name)
+
         juju.wait_timeout = 10 * 60
         juju.cli("set-model-constraints", f"arch={platform}")
+        yield juju
 
-        yield juju  # run the test
-
-        if request.session.testsfailed:
-            log = juju.debug_log(limit=30)
-            print(log, end="")
-
-        status = juju.cli("status")
-        debug_log = juju.debug_log(limit=1000)
-        logger.info(debug_log)
-        logger.info(status)
+    if model is not None and not keep_models:
+        juju.destroy_model(model_name, destroy_storage=True, force=True)
 
 
 @pytest.fixture

--- a/tests/spread/integration-charm/task.yaml
+++ b/tests/spread/integration-charm/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-charm
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-charm -- -x --model testing --keep-models
+  tox run -e integration-charm -- --model testing --keep-models

--- a/tests/spread/integration-charm/task.yaml
+++ b/tests/spread/integration-charm/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-charm
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-charm -- -x
+  tox run -e integration-charm -- -x --model testing --keep-models

--- a/tests/spread/integration-charm/task.yaml
+++ b/tests/spread/integration-charm/task.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+summary: integration-charm
+execute: |
+  cd "$SPREAD_PATH"
+  tox run -e integration-charm -- -x

--- a/tests/spread/integration-observability/task.yaml
+++ b/tests/spread/integration-observability/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-observability
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-observability -- -x
+  tox run -e integration-observability -- -x --model testing --keep-models

--- a/tests/spread/integration-observability/task.yaml
+++ b/tests/spread/integration-observability/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-observability
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-observability -- -x --model testing --keep-models
+  tox run -e integration-observability -- --model testing --keep-models

--- a/tests/spread/integration-observability/task.yaml
+++ b/tests/spread/integration-observability/task.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+summary: integration-observability
+execute: |
+  cd "$SPREAD_PATH"
+  tox run -e integration-observability -- -x

--- a/tests/spread/integration-provider/task.yaml
+++ b/tests/spread/integration-provider/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-provider
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-provider -- -x --model testing --keep-models
+  tox run -e integration-provider -- --model testing --keep-models

--- a/tests/spread/integration-provider/task.yaml
+++ b/tests/spread/integration-provider/task.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+summary: integration-provider
+execute: |
+  cd "$SPREAD_PATH"
+  tox run -e integration-provider -- -x

--- a/tests/spread/integration-provider/task.yaml
+++ b/tests/spread/integration-provider/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-provider
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-provider -- -x
+  tox run -e integration-provider -- -x --model testing --keep-models

--- a/tests/spread/integration-tls/task.yaml
+++ b/tests/spread/integration-tls/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-tls
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-tls -- -x --model testing --keep-models
+  tox run -e integration-tls -- --model testing --keep-models

--- a/tests/spread/integration-tls/task.yaml
+++ b/tests/spread/integration-tls/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-tls
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-tls -- -x
+  tox run -e integration-tls -- -x --model testing --keep-models

--- a/tests/spread/integration-tls/task.yaml
+++ b/tests/spread/integration-tls/task.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+summary: integration-tls
+execute: |
+  cd "$SPREAD_PATH"
+  tox run -e integration-tls -- -x

--- a/tests/spread/integration-trust/task.yaml
+++ b/tests/spread/integration-trust/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-trust
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-trust -- -x --model testing --keep-models
+  tox run -e integration-trust -- --model testing --keep-models

--- a/tests/spread/integration-trust/task.yaml
+++ b/tests/spread/integration-trust/task.yaml
@@ -1,0 +1,7 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+summary: integration-trust
+execute: |
+  cd "$SPREAD_PATH"
+  tox run -e integration-trust -- -x

--- a/tests/spread/integration-trust/task.yaml
+++ b/tests/spread/integration-trust/task.yaml
@@ -4,4 +4,4 @@
 summary: integration-trust
 execute: |
   cd "$SPREAD_PATH"
-  tox run -e integration-trust -- -x
+  tox run -e integration-trust -- -x --model testing --keep-models


### PR DESCRIPTION
This PR migrates our test suite to spread. This was done by basically copying and pasting the setup we currently have for the object storage integrators. 

We removed the pin on charmcraft revisions since the stable risk was fixed.

I noticed that the original implementation was not taking advantage of the model created by concierge, so I also reworked the juju fixture (similar to the bundle one) so that we have a nice integration with the GH workflow logs