### PR TITLE
[PRA-168] - Charm errors when related to the s3-integrator and bucket name is empty

### DIFF
--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -85,12 +85,12 @@ class S3ConnectionInfo(StateBase):
     @property
     def path(self) -> str:
         """Return the path in the S3 bucket."""
-        return self.relation_data["path"]
+        return self.relation_data.get("path", "")
 
     @property
     def bucket(self) -> str:
         """Return the name of the S3 bucket."""
-        return self.relation_data["bucket"]
+        return self.relation_data.get("bucket", "")
 
     @property
     def region(self) -> str:

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -57,16 +57,49 @@ class S3Manager(WithLogging):
                 ),
             )
 
-            try:
-                s3.list_buckets()
-            except ClientError as client_error:
-                self.logger.error(f"Invalid S3 credentials... {client_error}")
-                return False
-            except SSLError as ssl_error:
-                self.logger.error(f"SSL validation failed... {ssl_error}")
-                return False
-            except Exception as e:
-                self.logger.error(f"S3 related error {e}")
-                return False
-
-        return True
+            for attempt in range(2):
+                try:
+                    response = s3.list_objects_v2(
+                        Bucket=self.connection_info.bucket,
+                        Prefix=f"{self.connection_info.path}/",
+                        MaxKeys=1,
+                    )
+                    if response.get("KeyCount", 0) != 1:
+                        s3.put_object(
+                            Bucket=self.connection_info.bucket,
+                            Key=f"{self.connection_info.path}/",
+                            Body=b"",
+                        )
+                        continue
+                    return True
+                except ClientError as client_error:
+                    error_message = client_error.response["Error"]["Code"]
+                    if error_message == "NoSuchBucket":
+                        try:
+                            region = self.connection_info.region or "us-east-1"
+                            if region == "us-east-1":
+                                s3.create_bucket(Bucket=self.connection_info.bucket)
+                            else:
+                                s3.create_bucket(
+                                    Bucket=self.connection_info.bucket,
+                                    CreateBucketConfiguration={"LocationConstraint": region},
+                                )
+                            continue
+                        except ClientError as create_error:
+                            self.logger.error(f"Failed to create bucket... {create_error}")
+                            return False
+                    elif error_message == "PermanentRedirect":
+                        self.logger.error(
+                            f"S3 endpoint/region mismatch: bucket exists in a different region. "
+                            f"Update the endpoint or region configuration. {client_error}"
+                        )
+                    else:
+                        self.logger.error(f"Invalid S3 credentials... {client_error}")
+                    return False
+                except SSLError as ssl_error:
+                    self.logger.error(f"SSL validation failed... {ssl_error}")
+                    return False
+                except Exception as e:
+                    self.logger.error(f"S3 related error {e}")
+                    return False
+            return True

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -11,6 +11,7 @@ from functools import cached_property
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError, SSLError
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_fixed
 
 from common.utils import WithLogging, is_proxy_skipped
 from core.domain import S3ConnectionInfo
@@ -56,6 +57,48 @@ class S3Manager(WithLogging):
             self.logger.error(f"Failed to create bucket... {create_error}")
             return False
 
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(2),
+        retry=retry_if_exception(
+            lambda e: isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchBucket"
+        ),
+    )
+    def _verify_bucket_and_path(self, s3) -> bool:
+        """Verify read+write access to bucket/path, creating as needed. Retries with 2s backoff."""
+        try:
+            s3.list_objects_v2(
+                Bucket=self.connection_info.bucket,
+                Prefix=f"{self.connection_info.path}/",
+                MaxKeys=1,
+            )
+            s3.put_object(
+                Bucket=self.connection_info.bucket,
+                Key=f"{self.connection_info.path}/.keep",
+                Body=b"",
+            )
+            return True
+        except ClientError as client_error:
+            error_code = client_error.response["Error"]["Code"]
+            if error_code == "NoSuchBucket":
+                if not self._try_create_bucket(s3):
+                    return False
+                raise
+            elif error_code == "PermanentRedirect":
+                self.logger.error(
+                    f"S3 endpoint/region mismatch: bucket exists in a different region. "
+                    f"Update the endpoint or region configuration. {client_error}"
+                )
+            else:
+                self.logger.error(f"Invalid S3 credentials... {client_error}")
+            return False
+        except SSLError as ssl_error:
+            self.logger.error(f"SSL validation failed... {ssl_error}")
+            return False
+        except Exception as e:
+            self.logger.error(f"S3 related error {e}")
+            return False
+
     def verify(self) -> bool:
         """Verify S3 credentials."""
         with tempfile.NamedTemporaryFile() as ca_file:
@@ -74,38 +117,4 @@ class S3Manager(WithLogging):
                     proxies=self._get_proxy_config(),
                 ),
             )
-
-            for attempt in range(2):
-                try:
-                    s3.list_objects_v2(
-                        Bucket=self.connection_info.bucket,
-                        Prefix=f"{self.connection_info.path}/",
-                        MaxKeys=1,
-                    )
-                    s3.put_object(
-                        Bucket=self.connection_info.bucket,
-                        Key=f"{self.connection_info.path}/",
-                        Body=b"",
-                    )
-                    return True
-                except ClientError as client_error:
-                    error_code = client_error.response["Error"]["Code"]
-                    if error_code == "NoSuchBucket":
-                        if not self._try_create_bucket(s3):
-                            return False
-                        continue
-                    elif error_code == "PermanentRedirect":
-                        self.logger.error(
-                            f"S3 endpoint/region mismatch: bucket exists in a different region. "
-                            f"Update the endpoint or region configuration. {client_error}"
-                        )
-                    else:
-                        self.logger.error(f"Invalid S3 credentials... {client_error}")
-                    return False
-                except SSLError as ssl_error:
-                    self.logger.error(f"SSL validation failed... {ssl_error}")
-                    return False
-                except Exception as e:
-                    self.logger.error(f"S3 related error {e}")
-                    return False
-            return True
+            return self._verify_bucket_and_path(s3)

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -30,16 +30,34 @@ class S3Manager(WithLogging):
             aws_secret_access_key=self.connection_info.secret_key,
         )
 
-    def verify(self) -> bool:
-        """Verify S3 credentials."""
+    def _get_proxy_config(self) -> dict[str, str]:
+        """Return proxy configuration based on charm environment variables."""
         proxy_config: dict[str, str] = {}
-
         if not is_proxy_skipped(self.connection_info.endpoint or ""):
             if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
                 proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
             if os.environ.get("JUJU_CHARM_HTTP_PROXY"):
                 proxy_config["http"] = os.environ["JUJU_CHARM_HTTP_PROXY"]
+        return proxy_config
 
+    def _try_create_bucket(self, s3) -> bool:
+        """Try to create the S3 bucket. Returns True on success, False on failure."""
+        try:
+            region = self.connection_info.region or "us-east-1"
+            if region == "us-east-1":
+                s3.create_bucket(Bucket=self.connection_info.bucket)
+            else:
+                s3.create_bucket(
+                    Bucket=self.connection_info.bucket,
+                    CreateBucketConfiguration={"LocationConstraint": region},
+                )
+            return True
+        except ClientError as create_error:
+            self.logger.error(f"Failed to create bucket... {create_error}")
+            return False
+
+    def verify(self) -> bool:
+        """Verify S3 credentials."""
         with tempfile.NamedTemporaryFile() as ca_file:
             if tls_ca_chain := self.connection_info.tls_ca_chain:
                 ca_file.write("\n".join(tls_ca_chain).encode())
@@ -53,7 +71,7 @@ class S3Manager(WithLogging):
                 config=Config(
                     request_checksum_calculation="when_supported",
                     response_checksum_validation="when_supported",
-                    proxies=proxy_config,
+                    proxies=self._get_proxy_config(),
                 ),
             )
 
@@ -73,22 +91,12 @@ class S3Manager(WithLogging):
                         continue
                     return True
                 except ClientError as client_error:
-                    error_message = client_error.response["Error"]["Code"]
-                    if error_message == "NoSuchBucket":
-                        try:
-                            region = self.connection_info.region or "us-east-1"
-                            if region == "us-east-1":
-                                s3.create_bucket(Bucket=self.connection_info.bucket)
-                            else:
-                                s3.create_bucket(
-                                    Bucket=self.connection_info.bucket,
-                                    CreateBucketConfiguration={"LocationConstraint": region},
-                                )
-                            continue
-                        except ClientError as create_error:
-                            self.logger.error(f"Failed to create bucket... {create_error}")
+                    error_code = client_error.response["Error"]["Code"]
+                    if error_code == "NoSuchBucket":
+                        if not self._try_create_bucket(s3):
                             return False
-                    elif error_message == "PermanentRedirect":
+                        continue
+                    elif error_code == "PermanentRedirect":
                         self.logger.error(
                             f"S3 endpoint/region mismatch: bucket exists in a different region. "
                             f"Update the endpoint or region configuration. {client_error}"

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -77,18 +77,16 @@ class S3Manager(WithLogging):
 
             for attempt in range(2):
                 try:
-                    response = s3.list_objects_v2(
+                    s3.list_objects_v2(
                         Bucket=self.connection_info.bucket,
                         Prefix=f"{self.connection_info.path}/",
                         MaxKeys=1,
                     )
-                    if response.get("KeyCount", 0) != 1:
-                        s3.put_object(
-                            Bucket=self.connection_info.bucket,
-                            Key=f"{self.connection_info.path}/",
-                            Body=b"",
-                        )
-                        continue
+                    s3.put_object(
+                        Bucket=self.connection_info.bucket,
+                        Key=f"{self.connection_info.path}/",
+                        Body=b"",
+                    )
                     return True
                 except ClientError as client_error:
                     error_code = client_error.response["Error"]["Code"]

--- a/tests/unit/test_s3_managers.py
+++ b/tests/unit/test_s3_managers.py
@@ -40,7 +40,7 @@ def test_verify_bucket_and_path_exist():
 
     assert manager.verify() is True
     mock_s3.list_objects_v2.assert_called_once_with(Bucket="my-bucket", Prefix="logs/", MaxKeys=1)
-    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/.keep", Body=b"")
     mock_s3.create_bucket.assert_not_called()
 
 
@@ -50,7 +50,7 @@ def test_verify_bucket_exists_path_empty():
 
     assert manager.verify() is True
     mock_s3.list_objects_v2.assert_called_once_with(Bucket="my-bucket", Prefix="logs/", MaxKeys=1)
-    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/.keep", Body=b"")
     mock_s3.create_bucket.assert_not_called()
 
 
@@ -64,7 +64,7 @@ def test_verify_bucket_missing_creates_bucket_and_path():
 
     assert manager.verify() is True
     mock_s3.create_bucket.assert_called_once_with(Bucket="my-bucket")
-    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/.keep", Body=b"")
 
 
 def test_verify_bucket_missing_non_us_east_1_region():
@@ -81,7 +81,7 @@ def test_verify_bucket_missing_non_us_east_1_region():
         Bucket="my-bucket",
         CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
     )
-    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/.keep", Body=b"")
 
 
 def test_verify_composite_path():
@@ -93,7 +93,9 @@ def test_verify_composite_path():
     mock_s3.list_objects_v2.assert_called_once_with(
         Bucket="my-bucket", Prefix="logs/dev1/dev2/", MaxKeys=1
     )
-    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/dev1/dev2/", Body=b"")
+    mock_s3.put_object.assert_called_once_with(
+        Bucket="my-bucket", Key="logs/dev1/dev2/.keep", Body=b""
+    )
 
 
 def test_verify_read_but_no_write():

--- a/tests/unit/test_s3_managers.py
+++ b/tests/unit/test_s3_managers.py
@@ -1,0 +1,152 @@
+# Copyright 2024 Canonical Limited
+# See LICENSE file for licensing details.
+
+from dataclasses import dataclass
+from unittest import mock
+
+from botocore.exceptions import ClientError, SSLError
+
+from managers.s3 import S3Manager
+
+
+@dataclass
+class S3ConnectionInfoTester:
+    access_key: str = "access-key"
+    secret_key: str = "secret-key"
+    bucket: str = "my-bucket"
+    path: str = "logs"
+    region: str = "us-east-1"
+    endpoint: str = "https://s3.amazonaws.com"
+    tls_ca_chain: str = ""
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": "test"}}, "operation")
+
+
+def _make_manager(info: S3ConnectionInfoTester) -> tuple[S3Manager, mock.MagicMock]:
+    """Return an S3Manager wired to a mocked S3 client."""
+    manager = S3Manager(info)
+    mock_s3 = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    mock_session.client.return_value = mock_s3
+    manager.__dict__["session"] = mock_session
+    return manager, mock_s3
+
+
+def test_verify_bucket_and_path_exist():
+    """Bucket and path exist — list and write both succeed, returns True."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+
+    assert manager.verify() is True
+    mock_s3.list_objects_v2.assert_called_once_with(Bucket="my-bucket", Prefix="logs/", MaxKeys=1)
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.create_bucket.assert_not_called()
+
+
+def test_verify_bucket_exists_path_empty():
+    """Bucket exists but path is empty — put_object creates the marker, returns True."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+
+    assert manager.verify() is True
+    mock_s3.list_objects_v2.assert_called_once_with(Bucket="my-bucket", Prefix="logs/", MaxKeys=1)
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+    mock_s3.create_bucket.assert_not_called()
+
+
+def test_verify_bucket_missing_creates_bucket_and_path():
+    """Bucket does not exist (us-east-1) — creates bucket and path marker, returns True."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+    mock_s3.list_objects_v2.side_effect = [
+        _client_error("NoSuchBucket"),  # attempt 0: bucket missing
+        {},                              # attempt 1: bucket now exists
+    ]
+
+    assert manager.verify() is True
+    mock_s3.create_bucket.assert_called_once_with(Bucket="my-bucket")
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+
+
+def test_verify_bucket_missing_non_us_east_1_region():
+    """Bucket missing in eu-west-1 — creates with LocationConstraint, returns True."""
+    info = S3ConnectionInfoTester(region="eu-west-1")
+    manager, mock_s3 = _make_manager(info)
+    mock_s3.list_objects_v2.side_effect = [
+        _client_error("NoSuchBucket"),
+        {},
+    ]
+
+    assert manager.verify() is True
+    mock_s3.create_bucket.assert_called_once_with(
+        Bucket="my-bucket",
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/", Body=b"")
+
+
+def test_verify_composite_path():
+    """Hierarchical path (logs/dev1/dev2) — list and write use the full path, returns True."""
+    info = S3ConnectionInfoTester(path="logs/dev1/dev2")
+    manager, mock_s3 = _make_manager(info)
+
+    assert manager.verify() is True
+    mock_s3.list_objects_v2.assert_called_once_with(
+        Bucket="my-bucket", Prefix="logs/dev1/dev2/", MaxKeys=1
+    )
+    mock_s3.put_object.assert_called_once_with(
+        Bucket="my-bucket", Key="logs/dev1/dev2/", Body=b""
+    )
+
+
+def test_verify_read_but_no_write():
+    """Read access exists but write is denied — returns False."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+    mock_s3.put_object.side_effect = _client_error("AccessDenied")
+
+    assert manager.verify() is False
+    mock_s3.list_objects_v2.assert_called_once()
+    mock_s3.put_object.assert_called_once()
+    mock_s3.create_bucket.assert_not_called()
+
+
+def test_verify_no_create_bucket_permission():
+    """Bucket missing and no permission to create it — returns False."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+    mock_s3.list_objects_v2.side_effect = _client_error("NoSuchBucket")
+    mock_s3.create_bucket.side_effect = _client_error("AccessDenied")
+
+    assert manager.verify() is False
+    mock_s3.create_bucket.assert_called_once()
+    mock_s3.put_object.assert_not_called()
+
+
+def test_verify_no_read_permission():
+    """No permission to list bucket — returns False immediately."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+    mock_s3.list_objects_v2.side_effect = _client_error("AccessDenied")
+
+    assert manager.verify() is False
+    mock_s3.put_object.assert_not_called()
+    mock_s3.create_bucket.assert_not_called()
+
+
+def test_verify_permanent_redirect_wrong_region():
+    """Bucket exists in a different region than the configured endpoint — returns False."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester(region="eu-west-1"))
+    mock_s3.list_objects_v2.side_effect = _client_error("PermanentRedirect")
+
+    assert manager.verify() is False
+    mock_s3.put_object.assert_not_called()
+    mock_s3.create_bucket.assert_not_called()
+
+
+def test_verify_ssl_error():
+    """SSL certificate validation failure — returns False."""
+    manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
+    mock_s3.list_objects_v2.side_effect = SSLError(
+        endpoint_url="https://s3.amazonaws.com", error="certificate verify failed"
+    )
+
+    assert manager.verify() is False
+    mock_s3.put_object.assert_not_called()
+    mock_s3.create_bucket.assert_not_called()

--- a/tests/unit/test_s3_managers.py
+++ b/tests/unit/test_s3_managers.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Limited
+# Copyright 2026 Canonical Limited
 # See LICENSE file for licensing details.
 
 from dataclasses import dataclass
@@ -59,7 +59,7 @@ def test_verify_bucket_missing_creates_bucket_and_path():
     manager, mock_s3 = _make_manager(S3ConnectionInfoTester())
     mock_s3.list_objects_v2.side_effect = [
         _client_error("NoSuchBucket"),  # attempt 0: bucket missing
-        {},                              # attempt 1: bucket now exists
+        {},  # attempt 1: bucket now exists
     ]
 
     assert manager.verify() is True
@@ -93,9 +93,7 @@ def test_verify_composite_path():
     mock_s3.list_objects_v2.assert_called_once_with(
         Bucket="my-bucket", Prefix="logs/dev1/dev2/", MaxKeys=1
     )
-    mock_s3.put_object.assert_called_once_with(
-        Bucket="my-bucket", Key="logs/dev1/dev2/", Body=b""
-    )
+    mock_s3.put_object.assert_called_once_with(Bucket="my-bucket", Key="logs/dev1/dev2/", Body=b"")
 
 
 def test_verify_read_but_no_write():


### PR DESCRIPTION
## Summary

  Fixes #150 — the charm errored with `KeyError: 'bucket'` when the `bucket` config was empty,
  and separately would fail with `AccessDenied` because credential validation called
  `s3:ListAllMyBuckets`, a high-privilege operation that many scoped IAM users don't have.
  
  ## Problem

  The previous credential validation in `src/managers/s3.py` called `s3.list_buckets()`, which
  requires the `s3:ListAllMyBuckets` permission. This is a broad account-level operation. Users
  with scoped permissions (e.g. access only to a specific bucket) would get an `AccessDenied`
  error even though they had perfectly valid credentials for the bucket they actually needed.

  A second, independent bug existed: validation only checked read access (`list_objects_v2`) but
  not write access. This meant the charm would report a successful integration even when the IAM
  user lacked write permissions, causing Spark to fail silently at runtime when trying to write
  logs or checkpoints to S3.

  ## Changes

  ### `src/managers/s3.py` — Tiered permission validation

  Replaced the `list_buckets()` call with a minimal-permission validation flow that operates at
  the bucket/path level, matching the actual permissions the workload needs:

  1. **Verify read + write access** — calls `list_objects_v2` on the configured `bucket/path`,
     then `put_object` to write a path marker. Both must succeed; this ensures the IAM user has
     the permissions Spark actually needs.
  2. **If `NoSuchBucket`** — attempts to create the bucket (with the correct `LocationConstraint`
     for non-`us-east-1` regions). If creation succeeds, retries step 1. If creation is denied,
     blocks with an error.
  3. **If `AccessDenied`** at any step — blocks (returns `False`).
  4. **If `PermanentRedirect`** — logs a clear message about an endpoint/region mismatch and
     blocks.
  5. **SSL errors / unexpected exceptions** — handled as before.

  This means users with scoped, least-privilege IAM policies (read + write on one bucket, no
  account-level list) now integrate successfully.

  ### `tests/unit/test_s3_managers.py` — New unit test suite

  Added 10 unit tests covering all branches of the new validation logic:

  | Test | Scenario |
  |---|---|
  | `test_verify_bucket_and_path_exist` | Happy path — bucket and path already exist |
  | `test_verify_bucket_exists_path_empty` | Bucket exists, path marker absent — marker gets created |
  | `test_verify_bucket_missing_creates_bucket_and_path` | Bucket missing (us-east-1) — bucket and path created |
  | `test_verify_bucket_missing_non_us_east_1_region` | Bucket missing in non-us-east-1 — `LocationConstraint` is set |
  | `test_verify_composite_path` | Nested path (`logs/dev1/dev2`) handled correctly |
  | `test_verify_read_but_no_write` | Read access only — validation blocks |
  | `test_verify_no_create_bucket_permission` | Bucket missing + no create permission — blocks |
  | `test_verify_no_read_permission` | No read access — blocks immediately |
  | `test_verify_permanent_redirect_wrong_region` | Wrong region for bucket — blocks with clear message |
  | `test_verify_ssl_error` | SSL failure — blocks |

  ## Related

  - Closes #150
  - The same `list_buckets()` pattern exists in `spark-history-server` and should receive the
    same fix (tracked separately).