### PR TITLE
fix: comply with non-root user requirements

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,9 +26,13 @@ assumes:
       - juju < 3.6.10
       - juju >= 3.6.13
 
+charm-user: non-root
+
 containers:
   integration-hub:
     resource: integration-hub-image
+    uid: 584792
+    gid: 584792
 
 resources:
   integration-hub-image:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,9 +236,9 @@ def deploy_hub_charm(juju: jubilant.Juju, hub_charm: Path) -> str:
 
 
 @pytest.fixture
-def charm_name(deploy_hub_charm: str) -> str:
+def charm_name() -> str:
     """Return the name of the deployed charm."""
-    return deploy_hub_charm
+    return APP_NAME
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,6 +236,12 @@ def deploy_hub_charm(juju: jubilant.Juju, hub_charm: Path) -> str:
 
 
 @pytest.fixture
+def charm_name(deploy_hub_charm: str) -> str:
+    """Return the name of the deployed charm."""
+    return deploy_hub_charm
+
+
+@pytest.fixture
 def deploy_s3_integrator_charm(juju: jubilant.Juju, charm_versions, s3_credentials: S3Info) -> str:
     juju.deploy(**charm_versions.s3.deploy_dict())
     juju.wait(jubilant.all_agents_idle)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,8 +7,11 @@ import logging
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
+from typing import Dict, TypedDict
 
 import jubilant
+import lightkube
+from lightkube.resources.core_v1 import Pod
 
 BUCKET_NAME = "test-bucket"
 
@@ -94,3 +97,56 @@ def umask_named_temporary_file(*args, **kargs):
     os.umask(mask)
     os.chmod(file_desc.name, 0o666 & ~mask)
     return file_desc
+
+
+class ContainerSecurityContext(TypedDict):
+    """TypedDict representing Kubernetes container security context settings."""
+
+    runAsUser: int | None  # noqa N815
+    runAsGroup: int | None  # noqa N815
+    runAsNonRoot: bool | None  # noqa N815
+
+
+def generate_container_securitycontext_map(
+    metadata_yaml: dict, juju_user_id: int = 170
+) -> dict[str, ContainerSecurityContext]:
+    """Generate a mapping of container names to their security context UID/GID settings."""
+    c_uid_map = {}
+    for k, v in metadata_yaml.get("containers", {}).items():
+        c_uid_map[k] = ContainerSecurityContext(
+            runAsUser=v["uid"],
+            runAsGroup=v["gid"],
+        )
+    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    return c_uid_map
+
+
+def get_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application."""
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-lapp.kubernetes.io/name={application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE)
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
+def assert_security_context(
+    lightkube_client: lightkube.Client,
+    pod_name: str,
+    container_name: str,
+    container_securitycontext_map: Dict[str, ContainerSecurityContext],
+    model_name: str,
+) -> None:
+    """Assert that a container's security context matches expected UID/GID settings."""
+    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    container = next((c for c in containers if c.name == container_name), None)
+    security_context = container.securityContext
+    for key, value in container_securitycontext_map.get(container_name).items():
+        assert getattr(security_context, key) == value

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,9 +7,17 @@ import logging
 from pathlib import Path
 
 import jubilant
+import lightkube
+import pytest
 import yaml
 
-from .helpers import does_secret_exist, get_secret_data
+from .helpers import (
+    assert_security_context,
+    does_secret_exist,
+    generate_container_securitycontext_map,
+    get_pod_names,
+    get_secret_data,
+)
 from .types import AzureInfo, IntegrationTestsCharms
 
 logger = logging.getLogger(__name__)
@@ -18,10 +26,33 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 CONTAINER_NAME = "test-container"
 SECRET_NAME_PREFIX = "integrator-hub-conf-"
+CONTAINERS_SECURITY_CONTEXT_MAP = generate_container_securitycontext_map(METADATA)
 
 
 def test_build_and_deploy_hub_charm(juju: jubilant.Juju, deploy_hub_charm: str) -> None:
     juju.wait(lambda status: jubilant.all_active(status, APP_NAME))
+
+
+@pytest.mark.parametrize("container_name", list(CONTAINERS_SECURITY_CONTEXT_MAP.keys()))
+def test_container_security_context(
+    juju: jubilant.Juju,
+    charm_name: str,
+    container_name: str,
+) -> None:
+    """Test container security context is correctly set.
+
+    Verify that container spec defines the security context with correct
+    user ID and group ID.
+    """
+    lightkube_client = lightkube.Client()
+    pod_name = get_pod_names(juju.model, charm_name)[0]
+    assert_security_context(
+        lightkube_client,
+        pod_name,
+        container_name,
+        CONTAINERS_SECURITY_CONTEXT_MAP,
+        juju.model,
+    )
 
 
 def test_deploy_s3_integrator(


### PR DESCRIPTION
## Assessment

The **spark-integration-hub-k8s** charm was assessed for non-root user compliance:

| Component | Status | Details |
|-----------|--------|---------|
| **Charm container** | ❌ Non-compliant | `charm-user` was not set in `metadata.yaml` |
| **Workload container (integration-hub)** | ❌ Non-compliant | `uid` and `gid` were not set to `584792` |
| **Upstream image permissions** | ✅ Compliant | The upstream image (`ghcr.io/canonical/spark-integration-hub`) already has correct permissions — `/etc/hub/` and `/etc/hub/conf/` are owned by `_daemon_` (uid=584792, gid=584792) with `rwxr-x---` permissions |
| **Pebble operations** | ✅ Compliant | All read/write/exec operations in the charm code operate on paths already owned by `_daemon_` |

## Mitigation

1. **`metadata.yaml`**: Added `charm-user: non-root` to declare the charm runs as a non-root user.
2. **`metadata.yaml`**: Added `uid: 584792` and `gid: 584792` to the `integration-hub` container definition.

No image rebuild was needed since the upstream image already has correct permissions for the `_daemon_` user (uid/gid 584792).

## Verification

Added integration tests to verify the security context of deployed containers:

1. **`tests/integration/helpers.py`**: Added helper functions:
   - `ContainerSecurityContext` TypedDict
   - `generate_container_securitycontext_map()` — builds UID/GID map from `metadata.yaml` containers section
   - `get_pod_names()` — retrieves pod names for a given application
   - `assert_security_context()` — asserts container security context matches expected UID/GID values

2. **`tests/integration/test_charm.py`**: Added `test_container_security_context` — a parametrized test that verifies each container (including the `charm` Juju agent container with UID/GID 170) has the correct security context.

3. **`tests/integration/conftest.py`**: Added `charm_name` fixture to support the security context test.