### PR TITLE
[MISC] Bump dp workflows to v50.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,12 +52,9 @@ jobs:
           - .
           - tests/integration/app-charm
     name: Build charm | ${{ matrix.path }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v50.0.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
-    permissions:
-      actions: read
-      contents: read
 
   integration-test:
     name: Integration tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - 3/edge
 
+permissions:
+  contents: read
+
 jobs:
   release-checks:
     runs-on: ubuntu-22.04
@@ -51,9 +54,6 @@ jobs:
 
   ci-tests:
     uses: ./.github/workflows/ci.yaml
-    permissions:
-      actions: read
-      contents: read
 
   release-libs:
     name: Release to CharmHub
@@ -77,12 +77,11 @@ jobs:
     needs:
       - release-checks
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v50.0.0
     with:
       track: ${{ needs.release-checks.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
-      actions: read
       contents: write # Needed to create git tags

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -8,6 +8,9 @@ on:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tiobe-scan:
     name: Tiobe scan


### PR DESCRIPTION
I wanted to give a try to the newest DP workflow release, that does not require `actions: read` anymore: https://github.com/canonical/data-platform-workflows/releases/tag/v50.0.0