### PR TITLE
[PRA-354] Migrate and improve renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,32 +1,45 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
     "github>canonical/data-platform//renovate_presets/charm.json5",
+    "helpers:pinGitHubActionDigests",
   ],
-  "reviewers": ["team:processing"],
-  // Between 1AM and 6:59AM, first Friday of the month
-  "schedule": ["* 1-6 1-7 * 5"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 1-6 1-7 * 5"]
+  // Between 1AM and 6:59AM, Friday mid-month
+  schedule: ["* 1-6 14-21 * 5"],
+  lockFileMaintenance: {
+    enabled: true,
+    // Between 1AM and 6:59AM, first Friday of the month
+    schedule: ["* 1-6 1-7 * 5"],
   },
-  "ignoreDeps": ["ubuntu"],
-  "customManagers": [
+  commitMessagePrefix: "[RENOVATE] ",
+  ignoreDeps: ["ubuntu"],
+  customManagers: [
     {
-      "customType": "regex",
-      "fileMatch": ["(^|/)metadata\\.yaml$"],
-      "matchStrings": [
-        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      customType: "regex",
+      managerFilePatterns: ["metadata.yaml"],
+      matchStrings: [
+        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
       ],
-      "datasourceTemplate": "docker"
-    }
+      datasourceTemplate: "docker",
+    },
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/canonical/spark-integration-hub"],
-      "pinDigests": true,
-      "allowedVersions": "/^3-/"
-    }
-  ]
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/canonical/spark-integration-hub"],
+      pinDigests: true,
+      allowedVersions: "/^3-/",
+    },
+    {
+      description: "Combine all charmcraft|metadata.yaml dependencies into a single PR",
+      matchFileNames: ["charmcraft.yaml", "metadata.yaml"],
+      groupName: "Charm dependencies",
+      groupSlug: "charm-deps",
+    },
+    {
+      description: "Require manual approval on Dashboard for major updates",
+      matchUpdateTypes: ["major"],
+      dependencyDashboardApproval: true,
+    },
+  ],
 }


### PR DESCRIPTION
Similar to https://github.com/canonical/spark-history-server-k8s-operator/pull/196, this PR:
- Prettifies the file and migrate to the new syntax
- Pins GH actions to their digest
- Removes the reviewer assignment since we have a CODEOWNERS
- Adds the `[RENOVATE] ` prefix
- Reduces the # of PRs by making major updates a manual trigger and grouping everything happening in charmcraft.yaml and metadata.yaml under one group

The schedule is:
- mid month of the general updates, so that we can pick the newer rocks being released in the first half of the month
- two weeks later (back to beginning of the next month) for the lock file maintenance to avoid conflicts on poetry.lock